### PR TITLE
Change vendor namespace to ndrstmr

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,11 @@
+<?php
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__ . '/Classes')
+    ->in(__DIR__ . '/Tests');
+
+return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR12' => true,
+    ])
+    ->setFinder($finder);

--- a/Classes/Domain/Model/Room.php
+++ b/Classes/Domain/Model/Room.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Domain\Model;
+
+use Doctrine\ORM\Mapping as ORM;
+use TYPO3\CMS\Extbase\Domain\Model\AbstractEntity;
+
+/**
+ * Conference room.
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'tx_dt3pace_domain_model_room')]
+class Room extends AbstractEntity
+{
+    #[ORM\Column(type: 'string', length: 255)]
+    protected string $name = '';
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    protected int $capacity = 0;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getCapacity(): int
+    {
+        return $this->capacity;
+    }
+
+    public function setCapacity(int $capacity): void
+    {
+        $this->capacity = $capacity;
+    }
+}

--- a/Classes/Domain/Model/Session.php
+++ b/Classes/Domain/Model/Session.php
@@ -1,0 +1,184 @@
+<?php
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Domain\Model;
+
+use Doctrine\ORM\Mapping as ORM;
+use TYPO3\CMS\Extbase\Domain\Model\AbstractEntity;
+use TYPO3\CMS\Extbase\Domain\Model\FileReference;
+use TYPO3\CMS\Extbase\Domain\Model\FrontendUser;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+
+/**
+ * Represents a conference session.
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'tx_dt3pace_domain_model_session')]
+class Session extends AbstractEntity
+{
+    /**
+     * Title of the session
+     */
+    #[ORM\Column(type: 'string', length: 255)]
+    protected string $title = '';
+
+    /**
+     * Session description
+     */
+    #[ORM\Column(type: 'text', nullable: true)]
+    protected string $description = '';
+
+    /**
+     * Current status
+     */
+    #[ORM\Column(type: 'string', enumType: SessionStatus::class)]
+    protected SessionStatus $status = SessionStatus::PROPOSED;
+
+    /**
+     * Number of votes
+     */
+    #[ORM\Column(type: 'integer')]
+    protected int $votes = 0;
+
+    /**
+     * Publication flag
+     */
+    #[ORM\Column(type: 'boolean')]
+    protected bool $isPublished = false;
+
+    /**
+     * Proposing frontend user
+     */
+    #[ORM\ManyToOne(targetEntity: FrontendUser::class)]
+    protected ?FrontendUser $proposer = null;
+
+    /**
+     * Assigned speakers
+     *
+     * @var ObjectStorage<Speaker>
+     */
+    #[ORM\ManyToMany(targetEntity: Speaker::class)]
+    protected ObjectStorage $speakers;
+
+    #[ORM\ManyToOne(targetEntity: Room::class)]
+    protected ?Room $room = null;
+
+    #[ORM\ManyToOne(targetEntity: Track::class)]
+    protected ?Track $track = null;
+
+    #[ORM\ManyToOne(targetEntity: TimeSlot::class)]
+    protected ?TimeSlot $timeSlot = null;
+
+    public function __construct()
+    {
+        $this->speakers = new ObjectStorage();
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): void
+    {
+        $this->description = $description;
+    }
+
+    public function getStatus(): SessionStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(SessionStatus $status): void
+    {
+        $this->status = $status;
+    }
+
+    public function getVotes(): int
+    {
+        return $this->votes;
+    }
+
+    public function addVote(): void
+    {
+        ++$this->votes;
+    }
+
+    public function isPublished(): bool
+    {
+        return $this->isPublished;
+    }
+
+    public function setIsPublished(bool $isPublished): void
+    {
+        $this->isPublished = $isPublished;
+    }
+
+    public function getProposer(): ?FrontendUser
+    {
+        return $this->proposer;
+    }
+
+    public function setProposer(?FrontendUser $proposer): void
+    {
+        $this->proposer = $proposer;
+    }
+
+    /**
+     * @return ObjectStorage<Speaker>
+     */
+    public function getSpeakers(): ObjectStorage
+    {
+        return $this->speakers;
+    }
+
+    public function addSpeaker(Speaker $speaker): void
+    {
+        $this->speakers->attach($speaker);
+    }
+
+    public function removeSpeaker(Speaker $speaker): void
+    {
+        $this->speakers->detach($speaker);
+    }
+
+    public function getRoom(): ?Room
+    {
+        return $this->room;
+    }
+
+    public function setRoom(?Room $room): void
+    {
+        $this->room = $room;
+    }
+
+    public function getTrack(): ?Track
+    {
+        return $this->track;
+    }
+
+    public function setTrack(?Track $track): void
+    {
+        $this->track = $track;
+    }
+
+    public function getTimeSlot(): ?TimeSlot
+    {
+        return $this->timeSlot;
+    }
+
+    public function setTimeSlot(?TimeSlot $timeSlot): void
+    {
+        $this->timeSlot = $timeSlot;
+    }
+}

--- a/Classes/Domain/Model/SessionStatus.php
+++ b/Classes/Domain/Model/SessionStatus.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Domain\Model;
+
+/**
+ * Status of a session proposal.
+ */
+enum SessionStatus: string
+{
+    case PROPOSED = 'proposed';
+    case SCHEDULED = 'scheduled';
+    case REJECTED = 'rejected';
+}

--- a/Classes/Domain/Model/Speaker.php
+++ b/Classes/Domain/Model/Speaker.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Domain\Model;
+
+use Doctrine\ORM\Mapping as ORM;
+use TYPO3\CMS\Extbase\Domain\Model\AbstractEntity;
+use TYPO3\CMS\Extbase\Domain\Model\FileReference;
+
+/**
+ * Represents a conference speaker.
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'tx_dt3pace_domain_model_speaker')]
+class Speaker extends AbstractEntity
+{
+    #[ORM\Column(type: 'string', length: 255)]
+    protected string $name = '';
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    protected string $bio = '';
+
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    protected string $company = '';
+
+    #[ORM\ManyToOne(targetEntity: FileReference::class, cascade: ['persist', 'remove'])]
+    protected ?FileReference $image = null;
+
+    #[ORM\Column(type: 'string', length: 255, unique: true)]
+    protected string $slug = '';
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getBio(): string
+    {
+        return $this->bio;
+    }
+
+    public function setBio(string $bio): void
+    {
+        $this->bio = $bio;
+    }
+
+    public function getCompany(): string
+    {
+        return $this->company;
+    }
+
+    public function setCompany(string $company): void
+    {
+        $this->company = $company;
+    }
+
+    public function getImage(): ?FileReference
+    {
+        return $this->image;
+    }
+
+    public function setImage(?FileReference $image): void
+    {
+        $this->image = $image;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(string $slug): void
+    {
+        $this->slug = $slug;
+    }
+}

--- a/Classes/Domain/Model/TimeSlot.php
+++ b/Classes/Domain/Model/TimeSlot.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Domain\Model;
+
+use Doctrine\ORM\Mapping as ORM;
+use TYPO3\CMS\Extbase\Domain\Model\AbstractEntity;
+
+/**
+ * Represents a time slot within the schedule.
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'tx_dt3pace_domain_model_timeslot')]
+class TimeSlot extends AbstractEntity
+{
+    #[ORM\Column(type: 'datetime_immutable')]
+    protected \DateTimeImmutable $start;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    protected \DateTimeImmutable $end;
+
+    public function __construct()
+    {
+        $this->start = new \DateTimeImmutable();
+        $this->end = new \DateTimeImmutable();
+    }
+
+    public function getStart(): \DateTimeImmutable
+    {
+        return $this->start;
+    }
+
+    public function setStart(\DateTimeImmutable $start): void
+    {
+        $this->start = $start;
+    }
+
+    public function getEnd(): \DateTimeImmutable
+    {
+        return $this->end;
+    }
+
+    public function setEnd(\DateTimeImmutable $end): void
+    {
+        $this->end = $end;
+    }
+}

--- a/Classes/Domain/Model/Track.php
+++ b/Classes/Domain/Model/Track.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Domain\Model;
+
+use Doctrine\ORM\Mapping as ORM;
+use TYPO3\CMS\Extbase\Domain\Model\AbstractEntity;
+
+/**
+ * Conference track.
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'tx_dt3pace_domain_model_track')]
+class Track extends AbstractEntity
+{
+    #[ORM\Column(type: 'string', length: 255)]
+    protected string $title = '';
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+}

--- a/Classes/Domain/Model/Vote.php
+++ b/Classes/Domain/Model/Vote.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Domain\Model;
+
+use Doctrine\ORM\Mapping as ORM;
+use TYPO3\CMS\Extbase\Domain\Model\AbstractEntity;
+use TYPO3\CMS\Extbase\Domain\Model\FrontendUser;
+
+/**
+ * Represents a single vote for a session.
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'tx_dt3pace_domain_model_vote', uniqueConstraints: [new ORM\UniqueConstraint(name: 'session_voter_unique', columns: ['session', 'voter'])])]
+class Vote extends AbstractEntity
+{
+    #[ORM\ManyToOne(targetEntity: Session::class)]
+    protected ?Session $session = null;
+
+    #[ORM\ManyToOne(targetEntity: FrontendUser::class)]
+    protected ?FrontendUser $voter = null;
+
+    public function getSession(): ?Session
+    {
+        return $this->session;
+    }
+
+    public function setSession(?Session $session): void
+    {
+        $this->session = $session;
+    }
+
+    public function getVoter(): ?FrontendUser
+    {
+        return $this->voter;
+    }
+
+    public function setVoter(?FrontendUser $voter): void
+    {
+        $this->voter = $voter;
+    }
+}

--- a/Configuration/TCA/tx_dt3pace_domain_model_room.php
+++ b/Configuration/TCA/tx_dt3pace_domain_model_room.php
@@ -1,0 +1,40 @@
+<?php
+return [
+    'ctrl' => [
+        'title' => 'Room',
+        'label' => 'name',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+        ],
+        'iconfile' => 'EXT:dt3_pace/Resources/Public/Icons/tx_dt3pace_domain_model_room.svg',
+    ],
+    'columns' => [
+        'hidden' => [
+            'label' => 'Hidden',
+            'config' => [
+                'type' => 'check',
+            ],
+        ],
+        'name' => [
+            'label' => 'Name',
+            'config' => [
+                'type' => 'input',
+                'required' => true,
+            ],
+        ],
+        'capacity' => [
+            'label' => 'Capacity',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'int',
+            ],
+        ],
+    ],
+    'types' => [
+        '0' => ['showitem' => 'hidden, name, capacity'],
+    ],
+];

--- a/Configuration/TCA/tx_dt3pace_domain_model_session.php
+++ b/Configuration/TCA/tx_dt3pace_domain_model_session.php
@@ -1,0 +1,101 @@
+<?php
+return [
+    'ctrl' => [
+        'title' => 'Session',
+        'label' => 'title',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+        ],
+        'iconfile' => 'EXT:dt3_pace/Resources/Public/Icons/tx_dt3pace_domain_model_session.svg',
+    ],
+    'columns' => [
+        'hidden' => [
+            'label' => 'Hidden',
+            'config' => [
+                'type' => 'check',
+            ],
+        ],
+        'title' => [
+            'label' => 'Title',
+            'config' => [
+                'type' => 'input',
+                'required' => true,
+            ],
+        ],
+        'description' => [
+            'label' => 'Description',
+            'config' => [
+                'type' => 'text',
+                'enableRichtext' => true,
+            ],
+        ],
+        'status' => [
+            'label' => 'Status',
+            'config' => [
+                'type' => 'input',
+                'size' => 20,
+            ],
+        ],
+        'votes' => [
+            'label' => 'Votes',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'int',
+            ],
+        ],
+        'is_published' => [
+            'label' => 'Published',
+            'config' => [
+                'type' => 'check',
+            ],
+        ],
+        'proposer' => [
+            'label' => 'Proposer',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'fe_users',
+            ],
+        ],
+        'speakers' => [
+            'label' => 'Speakers',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectMultipleSideBySide',
+                'foreign_table' => 'tx_dt3pace_domain_model_speaker',
+                'MM' => 'tx_dt3pace_session_speaker_mm',
+            ],
+        ],
+        'room' => [
+            'label' => 'Room',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'tx_dt3pace_domain_model_room',
+            ],
+        ],
+        'track' => [
+            'label' => 'Track',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'tx_dt3pace_domain_model_track',
+            ],
+        ],
+        'time_slot' => [
+            'label' => 'Time slot',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'tx_dt3pace_domain_model_timeslot',
+            ],
+        ],
+    ],
+    'types' => [
+        '0' => ['showitem' => 'hidden, title, description, status, votes, is_published, proposer, speakers, room, track, time_slot'],
+    ],
+];

--- a/Configuration/TCA/tx_dt3pace_domain_model_speaker.php
+++ b/Configuration/TCA/tx_dt3pace_domain_model_speaker.php
@@ -1,0 +1,59 @@
+<?php
+return [
+    'ctrl' => [
+        'title' => 'Speaker',
+        'label' => 'name',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+        ],
+        'iconfile' => 'EXT:dt3_pace/Resources/Public/Icons/tx_dt3pace_domain_model_speaker.svg',
+    ],
+    'columns' => [
+        'hidden' => [
+            'label' => 'Hidden',
+            'config' => [
+                'type' => 'check',
+            ],
+        ],
+        'name' => [
+            'label' => 'Name',
+            'config' => [
+                'type' => 'input',
+                'required' => true,
+            ],
+        ],
+        'bio' => [
+            'label' => 'Bio',
+            'config' => [
+                'type' => 'text',
+                'enableRichtext' => true,
+            ],
+        ],
+        'company' => [
+            'label' => 'Company',
+            'config' => [
+                'type' => 'input',
+            ],
+        ],
+        'image' => [
+            'label' => 'Image',
+            'config' => [
+                'type' => 'file',
+                'allowed' => 'common-media-types',
+            ],
+        ],
+        'slug' => [
+            'label' => 'Slug',
+            'config' => [
+                'type' => 'input',
+            ],
+        ],
+    ],
+    'types' => [
+        '0' => ['showitem' => 'hidden, name, bio, company, image, slug'],
+    ],
+];

--- a/Configuration/TCA/tx_dt3pace_domain_model_timeslot.php
+++ b/Configuration/TCA/tx_dt3pace_domain_model_timeslot.php
@@ -1,0 +1,40 @@
+<?php
+return [
+    'ctrl' => [
+        'title' => 'Time Slot',
+        'label' => 'start',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+        ],
+        'iconfile' => 'EXT:dt3_pace/Resources/Public/Icons/tx_dt3pace_domain_model_timeslot.svg',
+    ],
+    'columns' => [
+        'hidden' => [
+            'label' => 'Hidden',
+            'config' => [
+                'type' => 'check',
+            ],
+        ],
+        'start' => [
+            'label' => 'Start',
+            'config' => [
+                'type' => 'input',
+                'renderType' => 'inputDateTime',
+            ],
+        ],
+        'end' => [
+            'label' => 'End',
+            'config' => [
+                'type' => 'input',
+                'renderType' => 'inputDateTime',
+            ],
+        ],
+    ],
+    'types' => [
+        '0' => ['showitem' => 'hidden, start, end'],
+    ],
+];

--- a/Configuration/TCA/tx_dt3pace_domain_model_track.php
+++ b/Configuration/TCA/tx_dt3pace_domain_model_track.php
@@ -1,0 +1,33 @@
+<?php
+return [
+    'ctrl' => [
+        'title' => 'Track',
+        'label' => 'title',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+        ],
+        'iconfile' => 'EXT:dt3_pace/Resources/Public/Icons/tx_dt3pace_domain_model_track.svg',
+    ],
+    'columns' => [
+        'hidden' => [
+            'label' => 'Hidden',
+            'config' => [
+                'type' => 'check',
+            ],
+        ],
+        'title' => [
+            'label' => 'Title',
+            'config' => [
+                'type' => 'input',
+                'required' => true,
+            ],
+        ],
+    ],
+    'types' => [
+        '0' => ['showitem' => 'hidden, title'],
+    ],
+];

--- a/Configuration/TCA/tx_dt3pace_domain_model_vote.php
+++ b/Configuration/TCA/tx_dt3pace_domain_model_vote.php
@@ -1,0 +1,42 @@
+<?php
+return [
+    'ctrl' => [
+        'title' => 'Vote',
+        'label' => 'uid',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+        ],
+        'iconfile' => 'EXT:dt3_pace/Resources/Public/Icons/tx_dt3pace_domain_model_vote.svg',
+    ],
+    'columns' => [
+        'hidden' => [
+            'label' => 'Hidden',
+            'config' => [
+                'type' => 'check',
+            ],
+        ],
+        'session' => [
+            'label' => 'Session',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'tx_dt3pace_domain_model_session',
+            ],
+        ],
+        'voter' => [
+            'label' => 'Voter',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'fe_users',
+            ],
+        ],
+    ],
+    'types' => [
+        '0' => ['showitem' => 'hidden, session, voter'],
+    ],
+];

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,0 +1,7 @@
+.. include:: /Includes.rst.txt
+
+============================
+DT3-PACE Documentation
+============================
+
+This is the starting point for the documentation of the dt3_pace extension.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# dt3-pace
+# dt3_pace
+
 PACE - Planning And Conference Engine
+
+This extension provides a basic data model and tooling for managing conference sessions and schedules.
+
+Sprint 1 delivers the initial domain models, simple backend integration and development tooling.

--- a/Tests/Unit/SessionTest.php
+++ b/Tests/Unit/SessionTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Tests\Unit;
+
+use Ndrstmr\Dt3Pace\Domain\Model\Session;
+use Ndrstmr\Dt3Pace\Domain\Model\SessionStatus;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Ndrstmr\Dt3Pace\Domain\Model\Session
+ */
+class SessionTest extends TestCase
+{
+    public function testDefaultStatusIsProposed(): void
+    {
+        $session = new Session();
+        self::assertSame(SessionStatus::PROPOSED, $session->getStatus());
+    }
+
+    public function testAddVoteIncreasesCount(): void
+    {
+        $session = new Session();
+        $session->addVote();
+        self::assertSame(1, $session->getVotes());
+    }
+}

--- a/Tests/Unit/SpeakerTest.php
+++ b/Tests/Unit/SpeakerTest.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Tests\Unit;
+
+use Ndrstmr\Dt3Pace\Domain\Model\Speaker;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Ndrstmr\Dt3Pace\Domain\Model\Speaker
+ */
+class SpeakerTest extends TestCase
+{
+    public function testSlugCanBeSet(): void
+    {
+        $speaker = new Speaker();
+        $speaker->setSlug('john-doe');
+        self::assertSame('john-doe', $speaker->getSlug());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,32 @@
+{
+    "name": "ndrstmr/dt3_pace",
+    "description": "PACE - Planning And Conference Engine",
+    "type": "typo3-cms-extension",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "typo3/cms-core": "^13.4"
+    },
+    "require-dev": {
+        "typo3/testing-framework": "^8.0",
+        "phpunit/phpunit": "^10.0",
+        "phpstan/phpstan": "^1.11",
+        "friendsofphp/php-cs-fixer": "^3.0",
+        "rector/rector": "^0.18.0",
+        "typo3/tailor": "^2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Ndrstmr\\Dt3Pace\\": "Classes/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Ndrstmr\\Dt3Pace\\Tests\\": "Tests/"
+        }
+    },
+    "config": {
+        "platform": {
+            "php": "8.2"
+        }
+    }
+}

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'PACE - Planning And Conference Engine',
+    'description' => 'Conference management tools',
+    'category' => 'module',
+    'author' => 'DT3 Team',
+    'state' => 'beta',
+    'clearCacheOnLoad' => 1,
+    'version' => '1.0.0',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '13.4.0-13.4.99'
+        ],
+        'conflicts' => [],
+        'suggests' => []
+    ]
+];

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,8 @@
+includes:
+    - vendor/typo3/testing-framework/Resources/Core/Build/Configuration/PHPStan/Extension.neon
+
+parameters:
+    level: 9
+    paths:
+        - Classes
+        - Tests

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>Tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,7 @@
+<?php
+return Rector\Config\RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/Classes',
+    ])
+    ->withPhpSets()
+    ->withPhpVersion(80200);


### PR DESCRIPTION
## Summary
- use `ndrstmr` vendor in composer metadata
- adjust autoload namespaces and update domain models
- update unit tests to new namespace

## Testing
- `composer validate --no-check-all --strict`
- `composer install --no-interaction --no-progress` *(fails: cannot connect to repo.packagist.org)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/php-cs-fixer fix --dry-run` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685f9c2d9f14832e8e344c365f9a9e17