### PR TITLE
Implement frontend plugins and voting

### DIFF
--- a/Classes/Controller/SessionController.php
+++ b/Classes/Controller/SessionController.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Controller;
+
+use Ndrstmr\Dt3Pace\Domain\Model\Session;
+use Ndrstmr\Dt3Pace\Domain\Model\SessionStatus;
+use Ndrstmr\Dt3Pace\Domain\Model\Vote;
+use Ndrstmr\Dt3Pace\Domain\Repository\RoomRepository;
+use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
+use Ndrstmr\Dt3Pace\Domain\Repository\TimeSlotRepository;
+use Ndrstmr\Dt3Pace\Domain\Repository\VoteRepository;
+use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Extbase\Annotation\IgnoreValidation;
+use TYPO3\CMS\Extbase\Domain\Model\FrontendUser;
+use TYPO3\CMS\Extbase\Domain\Repository\FrontendUserRepository;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
+
+class SessionController extends ActionController
+{
+    public function __construct(
+        private readonly SessionRepository $sessionRepository,
+        private readonly VoteRepository $voteRepository,
+        private readonly RoomRepository $roomRepository,
+        private readonly TimeSlotRepository $timeSlotRepository,
+        private readonly FrontendUserRepository $frontendUserRepository,
+        private readonly PersistenceManager $persistenceManager
+    ) {
+    }
+
+    public function listAction(): void
+    {
+        $sessions = $this->sessionRepository->findPublishedAndScheduled();
+        $grouped = [];
+        foreach ($sessions as $session) {
+            $date = $session->getTimeSlot()?->getStart()->format('Y-m-d');
+            $grouped[$date][] = $session;
+        }
+        ksort($grouped);
+        $this->view->assign('sessionsByDay', $grouped);
+    }
+
+    public function gridAction(): void
+    {
+        $sessions = $this->sessionRepository->findPublishedAndScheduled();
+        $grid = [];
+        foreach ($sessions as $session) {
+            $slot = $session->getTimeSlot()?->getUid();
+            $room = $session->getRoom()?->getUid();
+            if ($slot && $room) {
+                $grid[$slot][$room] = $session;
+            }
+        }
+        $this->view->assignMultiple([
+            'rooms' => $this->roomRepository->findAll(),
+            'timeSlots' => $this->timeSlotRepository->findAll(),
+            'grid' => $grid,
+        ]);
+    }
+
+    #[IgnoreValidation('session')]
+    public function showAction(Session $session): void
+    {
+        $this->view->assign('session', $session);
+    }
+
+    public function newAction(): void
+    {
+        if ($this->getCurrentFrontendUser() === null) {
+            throw new \RuntimeException('Login required', 166832);
+        }
+    }
+
+    public function createAction(Session $newSession): void
+    {
+        $user = $this->getCurrentFrontendUser();
+        if ($user === null) {
+            throw new \RuntimeException('Login required', 166833);
+        }
+        $newSession->setStatus(SessionStatus::PROPOSED);
+        $newSession->setProposer($user);
+        $this->sessionRepository->add($newSession);
+        $this->persistenceManager->persistAll();
+        $this->redirect('listProposals');
+    }
+
+    public function listProposalsAction(): void
+    {
+        $this->view->assign('sessions', $this->sessionRepository->findProposed());
+    }
+
+    public function voteAction(int $session): JsonResponse
+    {
+        $user = $this->getCurrentFrontendUser();
+        if ($user === null) {
+            return new JsonResponse(['success' => false], 403);
+        }
+        $sessionObj = $this->sessionRepository->findByUid($session);
+        if ($sessionObj === null) {
+            return new JsonResponse(['success' => false], 404);
+        }
+        if ($this->voteRepository->findOneBySessionAndVoter($sessionObj, $user) !== null) {
+            return new JsonResponse(['success' => false, 'message' => 'already voted'], 400);
+        }
+        $vote = new Vote();
+        $vote->setSession($sessionObj);
+        $vote->setVoter($user);
+        $this->voteRepository->add($vote);
+        $sessionObj->addVote();
+        $this->sessionRepository->update($sessionObj);
+        $this->persistenceManager->persistAll();
+
+        return new JsonResponse(['success' => true, 'votes' => $sessionObj->getVotes()]);
+    }
+
+    public function listJsonAction(): JsonResponse
+    {
+        $sessions = $this->sessionRepository->findPublishedAndScheduled();
+        $data = [];
+        foreach ($sessions as $session) {
+            $data[] = [
+                'id' => $session->getUid(),
+                'title' => $session->getTitle(),
+                'room' => $session->getRoom()?->getUid(),
+                'timeslot' => $session->getTimeSlot()?->getUid(),
+            ];
+        }
+
+        return new JsonResponse($data);
+    }
+
+    private function getCurrentFrontendUser(): ?FrontendUser
+    {
+        $uid = (int)($GLOBALS['TSFE']->fe_user->user['uid'] ?? 0);
+        if ($uid === 0) {
+            return null;
+        }
+        return $this->frontendUserRepository->findByUid($uid);
+    }
+}

--- a/Classes/Controller/SpeakerController.php
+++ b/Classes/Controller/SpeakerController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Controller;
+
+use Ndrstmr\Dt3Pace\Domain\Model\Speaker;
+use Ndrstmr\Dt3Pace\Domain\Repository\SpeakerRepository;
+use TYPO3\CMS\Extbase\Annotation\IgnoreValidation;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+
+class SpeakerController extends ActionController
+{
+    public function __construct(private readonly SpeakerRepository $speakerRepository)
+    {
+    }
+
+    public function listAction(): void
+    {
+        $this->view->assign('speakers', $this->speakerRepository->findAll());
+    }
+
+    #[IgnoreValidation('speaker')]
+    public function showAction(Speaker $speaker): void
+    {
+        $this->view->assign('speaker', $speaker);
+    }
+}

--- a/Classes/Domain/Repository/SessionRepository.php
+++ b/Classes/Domain/Repository/SessionRepository.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Ndrstmr\Dt3Pace\Domain\Repository;
 
+use Ndrstmr\Dt3Pace\Domain\Model\Session;
 use Ndrstmr\Dt3Pace\Domain\Model\SessionStatus;
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
 class SessionRepository extends Repository
@@ -24,7 +26,27 @@ class SessionRepository extends Repository
                 )
             )
         );
-        $query->setOrderings(['votes' => \TYPO3\CMS\Extbase\Persistence\QueryInterface::ORDER_DESCENDING]);
+        $query->setOrderings(['votes' => QueryInterface::ORDER_DESCENDING]);
+        return $query->execute()->toArray();
+    }
+
+    public function findPublishedAndScheduled(): array
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->logicalAnd(
+                $query->equals('isPublished', true),
+                $query->equals('status', SessionStatus::SCHEDULED->value)
+            )
+        );
+        $query->setOrderings(['timeSlot' => QueryInterface::ORDER_ASCENDING]);
+        return $query->execute()->toArray();
+    }
+
+    public function findProposed(): array
+    {
+        $query = $this->createQuery();
+        $query->matching($query->equals('status', SessionStatus::PROPOSED->value));
         return $query->execute()->toArray();
     }
 }

--- a/Classes/Domain/Repository/SpeakerRepository.php
+++ b/Classes/Domain/Repository/SpeakerRepository.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Domain\Repository;
+
+use TYPO3\CMS\Extbase\Persistence\Repository;
+
+class SpeakerRepository extends Repository
+{
+}

--- a/Classes/Domain/Repository/VoteRepository.php
+++ b/Classes/Domain/Repository/VoteRepository.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Domain\Repository;
+
+use Ndrstmr\Dt3Pace\Domain\Model\Session;
+use TYPO3\CMS\Extbase\Domain\Model\FrontendUser;
+use TYPO3\CMS\Extbase\Persistence\Repository;
+
+class VoteRepository extends Repository
+{
+    public function findOneBySessionAndVoter(Session $session, FrontendUser $voter): ?object
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->logicalAnd(
+                $query->equals('session', $session->getUid()),
+                $query->equals('voter', $voter->getUid())
+            )
+        );
+        return $query->execute()->getFirst();
+    }
+}

--- a/Configuration/Routes/Default.yaml
+++ b/Configuration/Routes/Default.yaml
@@ -1,0 +1,32 @@
+routeEnhancers:
+  Dt3PaceSession:
+    type: Extbase
+    extension: Dt3Pace
+    plugin: Sessionshow
+    routes:
+      - routePath: '/agenda/{session_slug}'
+        _controller: 'Session::show'
+        _arguments:
+          session_slug: session
+    defaultController: 'Session::show'
+    aspects:
+      session_slug:
+        type: PersistedAliasMapper
+        tableName: tx_dt3pace_domain_model_session
+        routeFieldName: slug
+
+  Dt3PaceSpeaker:
+    type: Extbase
+    extension: Dt3Pace
+    plugin: Speakershow
+    routes:
+      - routePath: '/speaker/{speaker_slug}'
+        _controller: 'Speaker::show'
+        _arguments:
+          speaker_slug: speaker
+    defaultController: 'Speaker::show'
+    aspects:
+      speaker_slug:
+        type: PersistedAliasMapper
+        tableName: tx_dt3pace_domain_model_speaker
+        routeFieldName: slug

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+defined('TYPO3') or die();
+
+use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
+
+ExtensionUtility::registerPlugin('Ndrstmr.Dt3Pace', 'Agendalist', 'Agenda List');
+ExtensionUtility::registerPlugin('Ndrstmr.Dt3Pace', 'Agendagrid', 'Agenda Grid');
+ExtensionUtility::registerPlugin('Ndrstmr.Dt3Pace', 'Sessionshow', 'Session Detail');
+ExtensionUtility::registerPlugin('Ndrstmr.Dt3Pace', 'Speakerlist', 'Speaker List');
+ExtensionUtility::registerPlugin('Ndrstmr.Dt3Pace', 'Speakershow', 'Speaker Detail');
+ExtensionUtility::registerPlugin('Ndrstmr.Dt3Pace', 'Sessionform', 'Session Proposal');
+ExtensionUtility::registerPlugin('Ndrstmr.Dt3Pace', 'Sessionvoting', 'Proposal Voting');

--- a/Resources/Private/Templates/Session/Grid.html
+++ b/Resources/Private/Templates/Session/Grid.html
@@ -1,0 +1,28 @@
+<f:layout name="Default" />
+<f:section name="Main">
+<table id="session-grid" border="1">
+  <thead>
+    <tr>
+      <th>&nbsp;</th>
+      <f:for each="{rooms}" as="room">
+        <th>{room.name}</th>
+      </f:for>
+    </tr>
+  </thead>
+  <tbody>
+    <f:for each="{timeSlots}" as="slot">
+      <tr data-slot="{slot.uid}">
+        <th>{slot.start -> f:format.date(format:'H:i')} - {slot.end -> f:format.date(format:'H:i')}</th>
+        <f:for each="{rooms}" as="room">
+          <td data-room="{room.uid}">
+            <f:if condition="{grid.{slot.uid}.{room.uid}}">
+              {grid.{slot.uid}.{room.uid}.title}
+            </f:if>
+          </td>
+        </f:for>
+      </tr>
+    </f:for>
+  </tbody>
+</table>
+<f:asset.script identifier="grid-js" src="EXT:dt3_pace/Resources/Public/JavaScript/Grid.js" />
+</f:section>

--- a/Resources/Private/Templates/Session/List.html
+++ b/Resources/Private/Templates/Session/List.html
@@ -1,0 +1,13 @@
+<f:layout name="Default" />
+<f:section name="Main">
+  <f:for each="{sessionsByDay}" as="daySessions" key="day">
+    <h2>{day -> f:format.date(format:'d.m.Y')}</h2>
+    <ul>
+      <f:for each="{daySessions}" as="session">
+        <li>
+          <f:link.action action="show" arguments="{session: session}">{session.title}</f:link.action>
+        </li>
+      </f:for>
+    </ul>
+  </f:for>
+</f:section>

--- a/Resources/Private/Templates/Session/New.html
+++ b/Resources/Private/Templates/Session/New.html
@@ -1,0 +1,10 @@
+<f:layout name="Default" />
+<f:section name="Main">
+  <f:form action="create" object="{newSession}">
+    <label for="title">Title</label>
+    <f:form.textfield property="title" id="title" />
+    <label for="description">Description</label>
+    <f:form.textarea property="description" id="description" />
+    <f:form.submit value="Submit" />
+  </f:form>
+</f:section>

--- a/Resources/Private/Templates/Session/Proposals.html
+++ b/Resources/Private/Templates/Session/Proposals.html
@@ -1,0 +1,12 @@
+<f:layout name="Default" />
+<f:section name="Main">
+  <ul>
+    <f:for each="{sessions}" as="session">
+      <li>
+        {session.title} - {session.votes} votes
+        <button class="vote" data-session="{session.uid}">Vote</button>
+      </li>
+    </f:for>
+  </ul>
+  <f:asset.script identifier="proposal-js" src="EXT:dt3_pace/Resources/Public/JavaScript/Vote.js" />
+</f:section>

--- a/Resources/Private/Templates/Session/Show.html
+++ b/Resources/Private/Templates/Session/Show.html
@@ -1,0 +1,7 @@
+<f:layout name="Default" />
+<f:section name="Main">
+  <h2>{session.title}</h2>
+  <p>{session.description}</p>
+  <p><strong>Room:</strong> {session.room.name}</p>
+  <p><strong>Time:</strong> {session.timeSlot.start -> f:format.date(format:'H:i')}</p>
+</f:section>

--- a/Resources/Private/Templates/Speaker/List.html
+++ b/Resources/Private/Templates/Speaker/List.html
@@ -1,0 +1,10 @@
+<f:layout name="Default" />
+<f:section name="Main">
+  <ul>
+    <f:for each="{speakers}" as="speaker">
+      <li>
+        <f:link.action action="show" arguments="{speaker: speaker}">{speaker.name}</f:link.action> - {speaker.company}
+      </li>
+    </f:for>
+  </ul>
+</f:section>

--- a/Resources/Private/Templates/Speaker/Show.html
+++ b/Resources/Private/Templates/Speaker/Show.html
@@ -1,0 +1,6 @@
+<f:layout name="Default" />
+<f:section name="Main">
+  <h2>{speaker.name}</h2>
+  <p>{speaker.company}</p>
+  <p>{speaker.bio}</p>
+</f:section>

--- a/Resources/Public/JavaScript/Grid.js
+++ b/Resources/Public/JavaScript/Grid.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const update = () => {
+    fetch(TYPO3.settings.ajaxUrls['dt3pace_sessions_json'])
+      .then(r => r.json())
+      .then(data => {
+        document.querySelectorAll('#session-grid td').forEach(c => c.textContent = '');
+        data.forEach(item => {
+          const cell = document.querySelector(`#session-grid [data-slot="${item.timeslot}"] [data-room="${item.room}"]`);
+          if (cell) {
+            cell.textContent = item.title;
+          }
+        });
+      });
+  };
+  update();
+  setInterval(update, 30000);
+});

--- a/Resources/Public/JavaScript/Vote.js
+++ b/Resources/Public/JavaScript/Vote.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.vote').forEach(btn => {
+    btn.addEventListener('click', () => {
+      fetch(TYPO3.settings.ajaxUrls['dt3pace_session_vote'], {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ session: btn.dataset.session })
+      }).then(r => r.json()).then(data => {
+        if (data.success) {
+          btn.parentElement.innerHTML = `${btn.parentElement.textContent.split(' ')[0]} - ${data.votes} votes`;
+        }
+      });
+    });
+  });
+});

--- a/Tests/Unit/Controller/SessionControllerTest.php
+++ b/Tests/Unit/Controller/SessionControllerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Tests\Unit\Controller;
+
+use Ndrstmr\Dt3Pace\Controller\SessionController;
+use Ndrstmr\Dt3Pace\Domain\Model\Session;
+use Ndrstmr\Dt3Pace\Domain\Model\SessionStatus;
+use Ndrstmr\Dt3Pace\Domain\Model\Vote;
+use Ndrstmr\Dt3Pace\Domain\Repository\RoomRepository;
+use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
+use Ndrstmr\Dt3Pace\Domain\Repository\TimeSlotRepository;
+use Ndrstmr\Dt3Pace\Domain\Repository\VoteRepository;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Extbase\Domain\Model\FrontendUser;
+use TYPO3\CMS\Extbase\Domain\Repository\FrontendUserRepository;
+use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
+
+class SessionControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['TSFE'] = new class {
+            public $fe_user;
+            public function __construct() { $this->fe_user = new class { public $user = ['uid' => 1]; }; }
+        };
+    }
+
+    public function testCreateActionAddsSession(): void
+    {
+        $session = new Session();
+        $sessionRepository = $this->createMock(SessionRepository::class);
+        $voteRepository = $this->createMock(VoteRepository::class);
+        $roomRepository = $this->createMock(RoomRepository::class);
+        $slotRepository = $this->createMock(TimeSlotRepository::class);
+        $frontendUserRepository = $this->createMock(FrontendUserRepository::class);
+        $persistenceManager = $this->createMock(PersistenceManager::class);
+
+        $user = new FrontendUser();
+        $frontendUserRepository->method('findByUid')->willReturn($user);
+
+        $sessionRepository->expects($this->once())->method('add')->with($session);
+        $persistenceManager->expects($this->once())->method('persistAll');
+
+        $controller = new SessionController($sessionRepository, $voteRepository, $roomRepository, $slotRepository, $frontendUserRepository, $persistenceManager);
+        $controller->createAction($session);
+
+        $this->assertSame(SessionStatus::PROPOSED, $session->getStatus());
+        $this->assertSame($user, $session->getProposer());
+    }
+
+    public function testVoteActionCreatesVote(): void
+    {
+        $session = new Session();
+        $session->_setProperty('uid', 5);
+        $sessionRepository = $this->createMock(SessionRepository::class);
+        $voteRepository = $this->createMock(VoteRepository::class);
+        $roomRepository = $this->createMock(RoomRepository::class);
+        $slotRepository = $this->createMock(TimeSlotRepository::class);
+        $frontendUserRepository = $this->createMock(FrontendUserRepository::class);
+        $persistenceManager = $this->createMock(PersistenceManager::class);
+
+        $user = new FrontendUser();
+        $user->_setProperty('uid', 1);
+        $frontendUserRepository->method('findByUid')->willReturn($user);
+        $sessionRepository->method('findByUid')->willReturn($session);
+        $voteRepository->method('findOneBySessionAndVoter')->willReturn(null);
+
+        $voteRepository->expects($this->once())->method('add')->with($this->isInstanceOf(Vote::class));
+        $sessionRepository->expects($this->once())->method('update')->with($session);
+        $persistenceManager->expects($this->once())->method('persistAll');
+
+        $controller = new SessionController($sessionRepository, $voteRepository, $roomRepository, $slotRepository, $frontendUserRepository, $persistenceManager);
+        $response = $controller->voteAction(5);
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $payload = json_decode((string)$response->getBody(), true);
+        $this->assertTrue($payload['success']);
+        $this->assertSame(1, $payload['votes']);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+use Ndrstmr\Dt3Pace\Controller\SessionController;
+use Ndrstmr\Dt3Pace\Controller\SpeakerController;
+use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
+
+defined('TYPO3') or die();
+
+ExtensionUtility::configurePlugin('Ndrstmr.Dt3Pace', 'Agendalist', [
+    SessionController::class => 'list,show'
+], []);
+
+ExtensionUtility::configurePlugin('Ndrstmr.Dt3Pace', 'Agendagrid', [
+    SessionController::class => 'grid,listJson'
+], [SessionController::class => 'listJson']);
+
+ExtensionUtility::configurePlugin('Ndrstmr.Dt3Pace', 'Sessionshow', [
+    SessionController::class => 'show'
+], []);
+
+ExtensionUtility::configurePlugin('Ndrstmr.Dt3Pace', 'Speakerlist', [
+    SpeakerController::class => 'list,show'
+], []);
+
+ExtensionUtility::configurePlugin('Ndrstmr.Dt3Pace', 'Speakershow', [
+    SpeakerController::class => 'show'
+], []);
+
+ExtensionUtility::configurePlugin('Ndrstmr.Dt3Pace', 'Sessionform', [
+    SessionController::class => 'new,create'
+], [SessionController::class => 'create']);
+
+ExtensionUtility::configurePlugin('Ndrstmr.Dt3Pace', 'Sessionvoting', [
+    SessionController::class => 'listProposals,vote'
+], [SessionController::class => 'vote']);
+
+$GLOBALS['TYPO3_CONF_VARS']['FE']['ajaxRoutes']['dt3pace_session_vote'] = [
+    'path' => '/dt3pace/session/vote',
+    'target' => SessionController::class . '::voteAction',
+    'access' => 'public',
+    'methods' => ['POST'],
+];
+
+$GLOBALS['TYPO3_CONF_VARS']['FE']['ajaxRoutes']['dt3pace_sessions_json'] = [
+    'path' => '/dt3pace/sessions/json',
+    'target' => SessionController::class . '::listJsonAction',
+    'access' => 'public',
+];


### PR DESCRIPTION
## Summary
- add Session and Speaker controllers with actions for the front end
- create repositories for speakers and votes
- implement additional queries in SessionRepository
- register seven frontend plugins and Ajax routes
- add templates and JavaScript for listing, grids and voting
- configure clean routes for sessions and speakers
- provide unit tests for session controller logic

## Testing
- `composer install` *(fails: ext-dom, ext-intl missing)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fbf1875a4832e834551d17b02388f