### PR TITLE
Add events and dispatching

### DIFF
--- a/Classes/Controller/SchedulerController.php
+++ b/Classes/Controller/SchedulerController.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Ndrstmr\Dt3Pace\Controller;
 
 use Ndrstmr\Dt3Pace\Domain\Model\SessionStatus;
+use Ndrstmr\Dt3Pace\Domain\Model\Session;
+use Ndrstmr\Dt3Pace\Domain\Model\Room;
+use Ndrstmr\Dt3Pace\Domain\Model\TimeSlot;
 use Ndrstmr\Dt3Pace\Domain\Repository\RoomRepository;
 use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
 use Ndrstmr\Dt3Pace\Domain\Repository\TimeSlotRepository;
@@ -13,6 +16,8 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Core\Http\JsonResponse;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Ndrstmr\Dt3Pace\Event\SessionStatusChangedEvent;
 
 class SchedulerController extends ActionController
 {
@@ -20,8 +25,10 @@ class SchedulerController extends ActionController
         private readonly SessionRepository $sessionRepository,
         private readonly RoomRepository $roomRepository,
         private readonly TimeSlotRepository $timeSlotRepository,
-        private readonly PersistenceManager $persistenceManager
+        private readonly PersistenceManager $persistenceManager,
+        EventDispatcherInterface $eventDispatcher
     ) {
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     public function initializeView(ViewInterface $view): void
@@ -40,16 +47,23 @@ class SchedulerController extends ActionController
     public function updateSessionSlotAction(int $session, int $room, int $timeSlot): JsonResponse
     {
         $sessionObj = $this->sessionRepository->findByUid($session);
+        /** @var Session|null $sessionObj */
         $roomObj = $this->roomRepository->findByUid($room);
+        /** @var Room|null $roomObj */
         $slotObj = $this->timeSlotRepository->findByUid($timeSlot);
+        /** @var TimeSlot|null $slotObj */
         if ($sessionObj === null || $roomObj === null || $slotObj === null) {
             return new JsonResponse(['success' => false], 400);
         }
+        $oldStatus = $sessionObj->getStatus();
         $sessionObj->setRoom($roomObj);
         $sessionObj->setTimeSlot($slotObj);
         $sessionObj->setStatus(SessionStatus::SCHEDULED);
         $this->sessionRepository->update($sessionObj);
         $this->persistenceManager->persistAll();
+        $this->eventDispatcher->dispatch(
+            new SessionStatusChangedEvent($sessionObj, $oldStatus, SessionStatus::SCHEDULED)
+        );
         return new JsonResponse(['success' => true]);
     }
 }

--- a/Classes/Event/AfterVoteAddedEvent.php
+++ b/Classes/Event/AfterVoteAddedEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Event;
+
+use Ndrstmr\Dt3Pace\Domain\Model\Vote;
+
+/**
+ * Event dispatched after a vote was added and persisted.
+ */
+final class AfterVoteAddedEvent
+{
+    public function __construct(private readonly Vote $vote)
+    {
+    }
+
+    public function getVote(): Vote
+    {
+        return $this->vote;
+    }
+}

--- a/Classes/Event/SessionStatusChangedEvent.php
+++ b/Classes/Event/SessionStatusChangedEvent.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Event;
+
+use Ndrstmr\Dt3Pace\Domain\Model\Session;
+use Ndrstmr\Dt3Pace\Domain\Model\SessionStatus;
+
+/**
+ * Event dispatched after a session's status changed.
+ */
+final class SessionStatusChangedEvent
+{
+    public function __construct(
+        private readonly Session $session,
+        private readonly SessionStatus $previousStatus,
+        private readonly SessionStatus $newStatus
+    ) {
+    }
+
+    public function getSession(): Session
+    {
+        return $this->session;
+    }
+
+    public function getPreviousStatus(): SessionStatus
+    {
+        return $this->previousStatus;
+    }
+
+    public function getNewStatus(): SessionStatus
+    {
+        return $this->newStatus;
+    }
+}

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -5,3 +5,14 @@ DT3-PACE Documentation
 ============================
 
 This is the starting point for the documentation of the dt3_pace extension.
+
+Events
+======
+
+The extension dispatches several events that can be used by third-party
+extensions:
+
+* ``Ndrstmr\Dt3Pace\Event\AfterVoteAddedEvent`` – emitted after a ``Vote``
+  entity has been persisted.
+* ``Ndrstmr\Dt3Pace\Event\SessionStatusChangedEvent`` – emitted whenever a
+  ``Session`` changes its status.

--- a/Tests/Unit/SchedulerControllerTest.php
+++ b/Tests/Unit/SchedulerControllerTest.php
@@ -12,6 +12,7 @@ use Ndrstmr\Dt3Pace\Domain\Repository\TimeSlotRepository;
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
+use Psr\EventDispatcher\EventDispatcherInterface;
 
 class SchedulerControllerTest extends TestCase
 {
@@ -28,6 +29,7 @@ class SchedulerControllerTest extends TestCase
         $room = new \Ndrstmr\Dt3Pace\Domain\Model\Room();
         $slot = new \Ndrstmr\Dt3Pace\Domain\Model\TimeSlot();
         $persistenceManager = $this->createMock(PersistenceManager::class);
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 
         $sessionRepository->method('findByUid')->willReturn($session);
         $roomRepository->method('findByUid')->willReturn($room);
@@ -36,7 +38,7 @@ class SchedulerControllerTest extends TestCase
         $sessionRepository->expects($this->once())->method('update')->with($session);
         $persistenceManager->expects($this->once())->method('persistAll');
 
-        $controller = new SchedulerController($sessionRepository, $roomRepository, $slotRepository, $persistenceManager);
+        $controller = new SchedulerController($sessionRepository, $roomRepository, $slotRepository, $persistenceManager, $eventDispatcher);
         $response = $controller->updateSessionSlotAction(1, 2, 3);
 
         $this->assertInstanceOf(JsonResponse::class, $response);


### PR DESCRIPTION
## Summary
- implement `AfterVoteAddedEvent` and `SessionStatusChangedEvent`
- inject the event dispatcher into `SessionController` and `SchedulerController`
- dispatch events after votes and status changes
- document events
- adjust unit tests for new dependencies

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-intl --ignore-platform-req=ext-xml --ignore-platform-req=ext-xmlwriter`
- `./vendor/bin/php-cs-fixer fix --dry-run --diff`
- `./vendor/bin/phpstan analyse --error-format=raw`
- `./vendor/bin/phpunit` *(fails: PHPUnit requires the dom, xml, xmlwriter extensions)*
