### PR TITLE
Refactor session handling controllers

### DIFF
--- a/Classes/Controller/SessionApiController.php
+++ b/Classes/Controller/SessionApiController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Controller;
+
+use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
+use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+
+class SessionApiController extends ActionController
+{
+    public function __construct(private readonly SessionRepository $sessionRepository)
+    {
+    }
+
+    public function listJsonAction(): JsonResponse
+    {
+        $sessions = $this->sessionRepository->findPublishedAndScheduled();
+        $data = [];
+        foreach ($sessions as $session) {
+            $data[] = [
+                'id' => $session->getUid(),
+                'title' => $session->getTitle(),
+                'room' => $session->getRoom()?->getUid(),
+                'timeslot' => $session->getTimeSlot()?->getUid(),
+            ];
+        }
+
+        return new JsonResponse($data);
+    }
+}

--- a/Classes/Controller/SessionController.php
+++ b/Classes/Controller/SessionController.php
@@ -5,66 +5,20 @@ declare(strict_types=1);
 namespace Ndrstmr\Dt3Pace\Controller;
 
 use Ndrstmr\Dt3Pace\Domain\Model\Session;
-use Ndrstmr\Dt3Pace\Domain\Model\SessionStatus;
-use Ndrstmr\Dt3Pace\Domain\Model\Vote;
-use Ndrstmr\Dt3Pace\Domain\Repository\RoomRepository;
-use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
-use Ndrstmr\Dt3Pace\Domain\Repository\TimeSlotRepository;
-use Ndrstmr\Dt3Pace\Domain\Repository\VoteRepository;
 use Ndrstmr\Dt3Pace\Domain\Repository\NoteRepository;
-use TYPO3\CMS\Core\Http\JsonResponse;
-use Psr\EventDispatcher\EventDispatcherInterface;
-use Ndrstmr\Dt3Pace\Event\AfterVoteAddedEvent;
 use TYPO3\CMS\Extbase\Annotation\IgnoreValidation;
 use Ndrstmr\Dt3Pace\Domain\Model\FrontendUser;
 use Ndrstmr\Dt3Pace\Domain\Repository\FrontendUserRepository;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
-use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
 class SessionController extends ActionController
 {
     public function __construct(
-        private readonly SessionRepository $sessionRepository,
-        private readonly VoteRepository $voteRepository,
-        private readonly RoomRepository $roomRepository,
-        private readonly TimeSlotRepository $timeSlotRepository,
         private readonly FrontendUserRepository $frontendUserRepository,
-        private readonly PersistenceManager $persistenceManager,
-        private readonly NoteRepository $noteRepository,
-        EventDispatcherInterface $eventDispatcher
+        private readonly NoteRepository $noteRepository
     ) {
-        $this->eventDispatcher = $eventDispatcher;
     }
 
-    public function listAction(): void
-    {
-        $sessions = $this->sessionRepository->findPublishedAndScheduled();
-        $grouped = [];
-        foreach ($sessions as $session) {
-            $date = $session->getTimeSlot()?->getStart()->format('Y-m-d');
-            $grouped[$date][] = $session;
-        }
-        ksort($grouped);
-        $this->view->assign('sessionsByDay', $grouped);
-    }
-
-    public function gridAction(): void
-    {
-        $sessions = $this->sessionRepository->findPublishedAndScheduled();
-        $grid = [];
-        foreach ($sessions as $session) {
-            $slot = $session->getTimeSlot()?->getUid();
-            $room = $session->getRoom()?->getUid();
-            if ($slot && $room) {
-                $grid[$slot][$room] = $session;
-            }
-        }
-        $this->view->assignMultiple([
-            'rooms' => $this->roomRepository->findAll(),
-            'timeSlots' => $this->timeSlotRepository->findAll(),
-            'grid' => $grid,
-        ]);
-    }
 
     #[IgnoreValidation('session')]
     public function showAction(Session $session): void
@@ -81,71 +35,6 @@ class SessionController extends ActionController
         ]);
     }
 
-    public function newAction(): void
-    {
-        if ($this->getCurrentFrontendUser() === null) {
-            throw new \RuntimeException('Login required', 166832);
-        }
-    }
-
-    public function createAction(Session $newSession): void
-    {
-        $user = $this->getCurrentFrontendUser();
-        if ($user === null) {
-            throw new \RuntimeException('Login required', 166833);
-        }
-        $newSession->setStatus(SessionStatus::PROPOSED);
-        $newSession->setProposer($user);
-        $this->sessionRepository->add($newSession);
-        $this->persistenceManager->persistAll();
-        $this->redirect('listProposals');
-    }
-
-    public function listProposalsAction(): void
-    {
-        $this->view->assign('sessions', $this->sessionRepository->findProposed());
-    }
-
-    public function voteAction(int $session): JsonResponse
-    {
-        $user = $this->getCurrentFrontendUser();
-        if ($user === null) {
-            return new JsonResponse(['success' => false], 403);
-        }
-        $sessionObj = $this->sessionRepository->findByUid($session);
-        if ($sessionObj === null) {
-            return new JsonResponse(['success' => false], 404);
-        }
-        if ($this->voteRepository->findOneBySessionAndVoter($sessionObj, $user) !== null) {
-            return new JsonResponse(['success' => false, 'message' => 'already voted'], 400);
-        }
-        $vote = new Vote();
-        $vote->setSession($sessionObj);
-        $vote->setVoter($user);
-        $this->voteRepository->add($vote);
-        $sessionObj->addVote();
-        $this->sessionRepository->update($sessionObj);
-        $this->persistenceManager->persistAll();
-        $this->eventDispatcher->dispatch(new AfterVoteAddedEvent($vote));
-
-        return new JsonResponse(['success' => true, 'votes' => $sessionObj->getVotes()]);
-    }
-
-    public function listJsonAction(): JsonResponse
-    {
-        $sessions = $this->sessionRepository->findPublishedAndScheduled();
-        $data = [];
-        foreach ($sessions as $session) {
-            $data[] = [
-                'id' => $session->getUid(),
-                'title' => $session->getTitle(),
-                'room' => $session->getRoom()?->getUid(),
-                'timeslot' => $session->getTimeSlot()?->getUid(),
-            ];
-        }
-
-        return new JsonResponse($data);
-    }
 
     private function getCurrentFrontendUser(): ?FrontendUser
     {

--- a/Classes/Controller/SessionListController.php
+++ b/Classes/Controller/SessionListController.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Controller;
+
+use Ndrstmr\Dt3Pace\Domain\Repository\RoomRepository;
+use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
+use Ndrstmr\Dt3Pace\Domain\Repository\TimeSlotRepository;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+
+class SessionListController extends ActionController
+{
+    public function __construct(
+        private readonly SessionRepository $sessionRepository,
+        private readonly RoomRepository $roomRepository,
+        private readonly TimeSlotRepository $timeSlotRepository
+    ) {
+    }
+
+    public function listAction(): void
+    {
+        $sessions = $this->sessionRepository->findPublishedAndScheduled();
+        $grouped = [];
+        foreach ($sessions as $session) {
+            $date = $session->getTimeSlot()?->getStart()->format('Y-m-d');
+            $grouped[$date][] = $session;
+        }
+        ksort($grouped);
+        $this->view->assign('sessionsByDay', $grouped);
+    }
+
+    public function gridAction(): void
+    {
+        $sessions = $this->sessionRepository->findPublishedAndScheduled();
+        $grid = [];
+        foreach ($sessions as $session) {
+            $slot = $session->getTimeSlot()?->getUid();
+            $room = $session->getRoom()?->getUid();
+            if ($slot && $room) {
+                $grid[$slot][$room] = $session;
+            }
+        }
+        $this->view->assignMultiple([
+            'rooms' => $this->roomRepository->findAll(),
+            'timeSlots' => $this->timeSlotRepository->findAll(),
+            'grid' => $grid,
+        ]);
+    }
+}

--- a/Classes/Controller/SessionProposalController.php
+++ b/Classes/Controller/SessionProposalController.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Controller;
+
+use Ndrstmr\Dt3Pace\Domain\Model\Session;
+use Ndrstmr\Dt3Pace\Domain\Model\SessionStatus;
+use Ndrstmr\Dt3Pace\Domain\Repository\FrontendUserRepository;
+use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
+
+class SessionProposalController extends ActionController
+{
+    public function __construct(
+        private readonly SessionRepository $sessionRepository,
+        private readonly FrontendUserRepository $frontendUserRepository,
+        private readonly PersistenceManager $persistenceManager
+    ) {
+    }
+
+    public function newAction(): void
+    {
+        if ($this->getCurrentFrontendUser() === null) {
+            throw new \RuntimeException('Login required', 166832);
+        }
+    }
+
+    public function createAction(Session $newSession): void
+    {
+        $user = $this->getCurrentFrontendUser();
+        if ($user === null) {
+            throw new \RuntimeException('Login required', 166833);
+        }
+        $newSession->setStatus(SessionStatus::PROPOSED);
+        $newSession->setProposer($user);
+        $this->sessionRepository->add($newSession);
+        $this->persistenceManager->persistAll();
+        $this->redirect('listProposals');
+    }
+
+    public function listProposalsAction(): void
+    {
+        $this->view->assign('sessions', $this->sessionRepository->findProposed());
+    }
+
+    private function getCurrentFrontendUser(): ?\Ndrstmr\Dt3Pace\Domain\Model\FrontendUser
+    {
+        $uid = (int)($GLOBALS['TSFE']->fe_user->user['uid'] ?? 0);
+        if ($uid === 0) {
+            return null;
+        }
+        return $this->frontendUserRepository->findByUid($uid);
+    }
+}

--- a/Classes/Controller/SessionVoteController.php
+++ b/Classes/Controller/SessionVoteController.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Controller;
+
+use Ndrstmr\Dt3Pace\Domain\Model\Vote;
+use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
+use Ndrstmr\Dt3Pace\Domain\Repository\VoteRepository;
+use Ndrstmr\Dt3Pace\Domain\Repository\FrontendUserRepository;
+use Ndrstmr\Dt3Pace\Event\AfterVoteAddedEvent;
+use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+class SessionVoteController extends ActionController
+{
+    public function __construct(
+        private readonly SessionRepository $sessionRepository,
+        private readonly VoteRepository $voteRepository,
+        private readonly FrontendUserRepository $frontendUserRepository,
+        private readonly PersistenceManager $persistenceManager,
+        EventDispatcherInterface $eventDispatcher
+    ) {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function voteAction(int $session): JsonResponse
+    {
+        $user = $this->getCurrentFrontendUser();
+        if ($user === null) {
+            return new JsonResponse(['success' => false], 403);
+        }
+        $sessionObj = $this->sessionRepository->findByUid($session);
+        if ($sessionObj === null) {
+            return new JsonResponse(['success' => false], 404);
+        }
+        if ($this->voteRepository->findOneBySessionAndVoter($sessionObj, $user) !== null) {
+            return new JsonResponse(['success' => false, 'message' => 'already voted'], 400);
+        }
+        $vote = new Vote();
+        $vote->setSession($sessionObj);
+        $vote->setVoter($user);
+        $this->voteRepository->add($vote);
+        $sessionObj->addVote();
+        $this->sessionRepository->update($sessionObj);
+        $this->persistenceManager->persistAll();
+        $this->eventDispatcher->dispatch(new AfterVoteAddedEvent($vote));
+
+        return new JsonResponse(['success' => true, 'votes' => $sessionObj->getVotes()]);
+    }
+
+    private function getCurrentFrontendUser(): ?\Ndrstmr\Dt3Pace\Domain\Model\FrontendUser
+    {
+        $uid = (int)($GLOBALS['TSFE']->fe_user->user['uid'] ?? 0);
+        if ($uid === 0) {
+            return null;
+        }
+        return $this->frontendUserRepository->findByUid($uid);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -2,6 +2,10 @@
 declare(strict_types=1);
 
 use Ndrstmr\Dt3Pace\Controller\SessionController;
+use Ndrstmr\Dt3Pace\Controller\SessionListController;
+use Ndrstmr\Dt3Pace\Controller\SessionProposalController;
+use Ndrstmr\Dt3Pace\Controller\SessionVoteController;
+use Ndrstmr\Dt3Pace\Controller\SessionApiController;
 use Ndrstmr\Dt3Pace\Controller\SpeakerController;
 use Ndrstmr\Dt3Pace\Controller\NoteController;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
@@ -9,12 +13,14 @@ use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 defined('TYPO3') or die();
 
 ExtensionUtility::configurePlugin('Ndrstmr.Dt3Pace', 'Agendalist', [
-    SessionController::class => 'list,show'
+    SessionListController::class => 'list',
+    SessionController::class => 'show'
 ], []);
 
 ExtensionUtility::configurePlugin('Ndrstmr.Dt3Pace', 'Agendagrid', [
-    SessionController::class => 'grid,listJson'
-], [SessionController::class => 'listJson']);
+    SessionListController::class => 'grid',
+    SessionApiController::class => 'listJson'
+], [SessionApiController::class => 'listJson']);
 
 ExtensionUtility::configurePlugin('Ndrstmr.Dt3Pace', 'Sessionshow', [
     SessionController::class => 'show'
@@ -29,12 +35,13 @@ ExtensionUtility::configurePlugin('Ndrstmr.Dt3Pace', 'Speakershow', [
 ], []);
 
 ExtensionUtility::configurePlugin('Ndrstmr.Dt3Pace', 'Sessionform', [
-    SessionController::class => 'new,create'
-], [SessionController::class => 'create']);
+    SessionProposalController::class => 'new,create'
+], [SessionProposalController::class => 'create']);
 
 ExtensionUtility::configurePlugin('Ndrstmr.Dt3Pace', 'Sessionvoting', [
-    SessionController::class => 'listProposals,vote'
-], [SessionController::class => 'vote']);
+    SessionProposalController::class => 'listProposals',
+    SessionVoteController::class => 'vote'
+], [SessionVoteController::class => 'vote']);
 
 ExtensionUtility::configurePlugin('Ndrstmr.Dt3Pace', 'Eventsummary', [
     NoteController::class => 'summary'
@@ -42,14 +49,14 @@ ExtensionUtility::configurePlugin('Ndrstmr.Dt3Pace', 'Eventsummary', [
 
 $GLOBALS['TYPO3_CONF_VARS']['FE']['ajaxRoutes']['dt3pace_session_vote'] = [
     'path' => '/dt3pace/session/vote',
-    'target' => SessionController::class . '::voteAction',
+    'target' => SessionVoteController::class . '::voteAction',
     'access' => 'public',
     'methods' => ['POST'],
 ];
 
 $GLOBALS['TYPO3_CONF_VARS']['FE']['ajaxRoutes']['dt3pace_sessions_json'] = [
     'path' => '/dt3pace/sessions/json',
-    'target' => SessionController::class . '::listJsonAction',
+    'target' => SessionApiController::class . '::listJsonAction',
     'access' => 'public',
 ];
 


### PR DESCRIPTION
## Summary
- split SessionController into dedicated controllers
- update plugin registration and ajax routes
- adjust unit tests to new controllers

## Testing
- `vendor/bin/phpunit` *(fails: missing dom, xml, xmlwriter extensions)*
- `vendor/bin/php-cs-fixer fix --dry-run --diff`
