### PR TITLE
Introduce shared FrontendUserProvider service

### DIFF
--- a/Classes/Controller/NoteController.php
+++ b/Classes/Controller/NoteController.php
@@ -7,7 +7,7 @@ namespace Ndrstmr\Dt3Pace\Controller;
 use Ndrstmr\Dt3Pace\Domain\Model\Note;
 use Ndrstmr\Dt3Pace\Domain\Repository\NoteRepository;
 use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
-use Ndrstmr\Dt3Pace\Domain\Repository\FrontendUserRepository;
+use Ndrstmr\Dt3Pace\Service\FrontendUserProvider;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
@@ -17,14 +17,14 @@ class NoteController extends ActionController
     public function __construct(
         private readonly NoteRepository $noteRepository,
         private readonly SessionRepository $sessionRepository,
-        private readonly FrontendUserRepository $frontendUserRepository,
+        private readonly FrontendUserProvider $frontendUserProvider,
         private readonly PersistenceManager $persistenceManager
     ) {
     }
 
     public function updateAction(int $session, string $note): JsonResponse
     {
-        $user = $this->getCurrentFrontendUser();
+        $user = $this->frontendUserProvider->getCurrentFrontendUser();
         if ($user === null) {
             return new JsonResponse(['success' => false], 403);
         }
@@ -46,7 +46,7 @@ class NoteController extends ActionController
 
     public function summaryAction(): void
     {
-        $user = $this->getCurrentFrontendUser();
+        $user = $this->frontendUserProvider->getCurrentFrontendUser();
         if ($user === null) {
             $this->view->assign('notes', []);
             return;
@@ -55,12 +55,5 @@ class NoteController extends ActionController
         $this->view->assign('notes', $notes);
     }
 
-    private function getCurrentFrontendUser(): ?\Ndrstmr\Dt3Pace\Domain\Model\FrontendUser
-    {
-        $uid = (int)($GLOBALS['TSFE']->fe_user->user['uid'] ?? 0);
-        if ($uid === 0) {
-            return null;
-        }
-        return $this->frontendUserRepository->findByUid($uid);
-    }
 }
+

--- a/Classes/Controller/SessionController.php
+++ b/Classes/Controller/SessionController.php
@@ -7,15 +7,14 @@ namespace Ndrstmr\Dt3Pace\Controller;
 use Ndrstmr\Dt3Pace\Domain\Model\Session;
 use Ndrstmr\Dt3Pace\Domain\Repository\NoteRepository;
 use TYPO3\CMS\Extbase\Annotation\IgnoreValidation;
-use Ndrstmr\Dt3Pace\Domain\Model\FrontendUser;
-use Ndrstmr\Dt3Pace\Domain\Repository\FrontendUserRepository;
+use Ndrstmr\Dt3Pace\Service\FrontendUserProvider;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 class SessionController extends ActionController
 {
     public function __construct(
-        private readonly FrontendUserRepository $frontendUserRepository,
-        private readonly NoteRepository $noteRepository
+        private readonly NoteRepository $noteRepository,
+        private readonly FrontendUserProvider $frontendUserProvider
     ) {
     }
 
@@ -23,7 +22,7 @@ class SessionController extends ActionController
     #[IgnoreValidation('session')]
     public function showAction(Session $session): void
     {
-        $user = $this->getCurrentFrontendUser();
+        $user = $this->frontendUserProvider->getCurrentFrontendUser();
         $note = null;
         if ($user !== null) {
             $note = $this->noteRepository->findOneByUserAndSession($user, $session);
@@ -36,12 +35,5 @@ class SessionController extends ActionController
     }
 
 
-    private function getCurrentFrontendUser(): ?FrontendUser
-    {
-        $uid = (int)($GLOBALS['TSFE']->fe_user->user['uid'] ?? 0);
-        if ($uid === 0) {
-            return null;
-        }
-        return $this->frontendUserRepository->findByUid($uid);
-    }
 }
+

--- a/Classes/Service/FrontendUserProvider.php
+++ b/Classes/Service/FrontendUserProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Service;
+
+use Ndrstmr\Dt3Pace\Domain\Model\FrontendUser;
+use Ndrstmr\Dt3Pace\Domain\Repository\FrontendUserRepository;
+
+class FrontendUserProvider
+{
+    public function __construct(private readonly FrontendUserRepository $frontendUserRepository)
+    {
+    }
+
+    public function getCurrentFrontendUser(): ?FrontendUser
+    {
+        $uid = (int)($GLOBALS['TSFE']->fe_user->user['uid'] ?? 0);
+        if ($uid === 0) {
+            return null;
+        }
+
+        return $this->frontendUserRepository->findByUid($uid);
+    }
+}

--- a/Tests/Functional/NoteAjaxTest.php
+++ b/Tests/Functional/NoteAjaxTest.php
@@ -10,6 +10,7 @@ use Ndrstmr\Dt3Pace\Domain\Model\FrontendUser;
 use Ndrstmr\Dt3Pace\Domain\Repository\NoteRepository;
 use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
 use Ndrstmr\Dt3Pace\Domain\Repository\FrontendUserRepository;
+use Ndrstmr\Dt3Pace\Service\FrontendUserProvider;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
@@ -23,6 +24,7 @@ class NoteAjaxTest extends FunctionalTestCase
         $noteRepository = $this->createMock(NoteRepository::class);
         $sessionRepository = $this->createMock(SessionRepository::class);
         $frontendUserRepository = $this->createMock(FrontendUserRepository::class);
+        $frontendUserProvider = new \Ndrstmr\Dt3Pace\Service\FrontendUserProvider($frontendUserRepository);
         $persistenceManager = $this->createMock(PersistenceManager::class);
 
         $session = new Session();
@@ -34,7 +36,7 @@ class NoteAjaxTest extends FunctionalTestCase
         $frontendUserRepository->method('findByUid')->willReturn($user);
         $noteRepository->method('findOneByUserAndSession')->willReturn(null);
 
-        $controller = new NoteController($noteRepository, $sessionRepository, $frontendUserRepository, $persistenceManager);
+        $controller = new NoteController($noteRepository, $sessionRepository, $frontendUserProvider, $persistenceManager);
         $GLOBALS['TSFE'] = new class ($user) {
             public $fe_user;
             public function __construct($user)

--- a/Tests/Unit/Controller/NoteControllerTest.php
+++ b/Tests/Unit/Controller/NoteControllerTest.php
@@ -11,6 +11,7 @@ use Ndrstmr\Dt3Pace\Domain\Model\FrontendUser;
 use Ndrstmr\Dt3Pace\Domain\Repository\NoteRepository;
 use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
 use Ndrstmr\Dt3Pace\Domain\Repository\FrontendUserRepository;
+use Ndrstmr\Dt3Pace\Service\FrontendUserProvider;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use PHPUnit\Framework\TestCase;
@@ -35,6 +36,7 @@ class NoteControllerTest extends TestCase
         $noteRepository = $this->createMock(NoteRepository::class);
         $sessionRepository = $this->createMock(SessionRepository::class);
         $frontendUserRepository = $this->createMock(FrontendUserRepository::class);
+        $frontendUserProvider = new \Ndrstmr\Dt3Pace\Service\FrontendUserProvider($frontendUserRepository);
         $persistenceManager = $this->createMock(PersistenceManager::class);
 
         $session = new Session();
@@ -49,7 +51,7 @@ class NoteControllerTest extends TestCase
         $noteRepository->expects($this->once())->method('add')->with($this->isInstanceOf(Note::class));
         $persistenceManager->expects($this->once())->method('persistAll');
 
-        $controller = new NoteController($noteRepository, $sessionRepository, $frontendUserRepository, $persistenceManager);
+        $controller = new NoteController($noteRepository, $sessionRepository, $frontendUserProvider, $persistenceManager);
         $response = $controller->updateAction(5, 'text');
 
         $this->assertInstanceOf(JsonResponse::class, $response);


### PR DESCRIPTION
## Summary
- add FrontendUserProvider for retrieving the logged in FE user
- use the new provider in SessionController and NoteController
- adjust unit and functional tests for the new dependency

## Testing
- `composer install --no-interaction --ignore-platform-reqs`
- `vendor/bin/phpstan analyse` *(fails: Found 36 errors)*
- `vendor/bin/phpunit` *(failed: missing PHP extensions)*
