### PR TITLE
Move note update action to dedicated API controller

### DIFF
--- a/Classes/Controller/NoteApiController.php
+++ b/Classes/Controller/NoteApiController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Controller;
+
+use Ndrstmr\Dt3Pace\Domain\Model\Note;
+use Ndrstmr\Dt3Pace\Domain\Repository\NoteRepository;
+use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
+use Ndrstmr\Dt3Pace\Service\FrontendUserProvider;
+use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
+
+class NoteApiController extends ActionController
+{
+    public function __construct(
+        private readonly NoteRepository $noteRepository,
+        private readonly SessionRepository $sessionRepository,
+        private readonly FrontendUserProvider $frontendUserProvider,
+        private readonly PersistenceManager $persistenceManager
+    ) {
+    }
+
+    public function updateAction(int $session, string $note): JsonResponse
+    {
+        $user = $this->frontendUserProvider->getCurrentFrontendUser();
+        if ($user === null) {
+            return new JsonResponse(['success' => false], 403);
+        }
+        $sessionObj = $this->sessionRepository->findByUid($session);
+        if ($sessionObj === null) {
+            return new JsonResponse(['success' => false], 404);
+        }
+        $noteObj = $this->noteRepository->findOneByUserAndSession($user, $sessionObj);
+        if ($noteObj === null) {
+            $noteObj = new Note();
+            $noteObj->setUser($user);
+            $noteObj->setSession($sessionObj);
+            $this->noteRepository->add($noteObj);
+        }
+        $noteObj->setNoteText($note);
+        $this->persistenceManager->persistAll();
+        return new JsonResponse(['success' => true]);
+    }
+}

--- a/Classes/Controller/NoteController.php
+++ b/Classes/Controller/NoteController.php
@@ -4,44 +4,16 @@ declare(strict_types=1);
 
 namespace Ndrstmr\Dt3Pace\Controller;
 
-use Ndrstmr\Dt3Pace\Domain\Model\Note;
 use Ndrstmr\Dt3Pace\Domain\Repository\NoteRepository;
-use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
 use Ndrstmr\Dt3Pace\Service\FrontendUserProvider;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
-use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
 class NoteController extends ActionController
 {
     public function __construct(
         private readonly NoteRepository $noteRepository,
-        private readonly SessionRepository $sessionRepository,
-        private readonly FrontendUserProvider $frontendUserProvider,
-        private readonly PersistenceManager $persistenceManager
+        private readonly FrontendUserProvider $frontendUserProvider
     ) {
-    }
-
-    public function updateAction(int $session, string $note): JsonResponse
-    {
-        $user = $this->frontendUserProvider->getCurrentFrontendUser();
-        if ($user === null) {
-            return new JsonResponse(['success' => false], 403);
-        }
-        $sessionObj = $this->sessionRepository->findByUid($session);
-        if ($sessionObj === null) {
-            return new JsonResponse(['success' => false], 404);
-        }
-        $noteObj = $this->noteRepository->findOneByUserAndSession($user, $sessionObj);
-        if ($noteObj === null) {
-            $noteObj = new Note();
-            $noteObj->setUser($user);
-            $noteObj->setSession($sessionObj);
-            $this->noteRepository->add($noteObj);
-        }
-        $noteObj->setNoteText($note);
-        $this->persistenceManager->persistAll();
-        return new JsonResponse(['success' => true]);
     }
 
     public function summaryAction(): void

--- a/Tests/Functional/NoteAjaxTest.php
+++ b/Tests/Functional/NoteAjaxTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Ndrstmr\Dt3Pace\Tests\Functional;
 
-use Ndrstmr\Dt3Pace\Controller\NoteController;
+use Ndrstmr\Dt3Pace\Controller\NoteApiController;
 use Ndrstmr\Dt3Pace\Domain\Model\Session;
 use Ndrstmr\Dt3Pace\Domain\Model\FrontendUser;
 use Ndrstmr\Dt3Pace\Domain\Repository\NoteRepository;
@@ -36,7 +36,7 @@ class NoteAjaxTest extends FunctionalTestCase
         $frontendUserRepository->method('findByUid')->willReturn($user);
         $noteRepository->method('findOneByUserAndSession')->willReturn(null);
 
-        $controller = new NoteController($noteRepository, $sessionRepository, $frontendUserProvider, $persistenceManager);
+        $controller = new NoteApiController($noteRepository, $sessionRepository, $frontendUserProvider, $persistenceManager);
         $GLOBALS['TSFE'] = new class ($user) {
             public $fe_user;
             public function __construct($user)

--- a/Tests/Unit/Controller/NoteControllerTest.php
+++ b/Tests/Unit/Controller/NoteControllerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Ndrstmr\Dt3Pace\Tests\Unit\Controller;
 
-use Ndrstmr\Dt3Pace\Controller\NoteController;
+use Ndrstmr\Dt3Pace\Controller\NoteApiController;
 use Ndrstmr\Dt3Pace\Domain\Model\Note;
 use Ndrstmr\Dt3Pace\Domain\Model\Session;
 use Ndrstmr\Dt3Pace\Domain\Model\FrontendUser;
@@ -51,7 +51,7 @@ class NoteControllerTest extends TestCase
         $noteRepository->expects($this->once())->method('add')->with($this->isInstanceOf(Note::class));
         $persistenceManager->expects($this->once())->method('persistAll');
 
-        $controller = new NoteController($noteRepository, $sessionRepository, $frontendUserProvider, $persistenceManager);
+        $controller = new NoteApiController($noteRepository, $sessionRepository, $frontendUserProvider, $persistenceManager);
         $response = $controller->updateAction(5, 'text');
 
         $this->assertInstanceOf(JsonResponse::class, $response);

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -8,6 +8,7 @@ use Ndrstmr\Dt3Pace\Controller\SessionVoteController;
 use Ndrstmr\Dt3Pace\Controller\SessionApiController;
 use Ndrstmr\Dt3Pace\Controller\SpeakerController;
 use Ndrstmr\Dt3Pace\Controller\NoteController;
+use Ndrstmr\Dt3Pace\Controller\NoteApiController;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 defined('TYPO3') or die();
@@ -62,7 +63,7 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['ajaxRoutes']['dt3pace_sessions_json'] = [
 
 $GLOBALS['TYPO3_CONF_VARS']['FE']['ajaxRoutes']['dt3pace_note_update'] = [
     'path' => '/dt3pace/note/update',
-    'target' => NoteController::class . '::updateAction',
+    'target' => NoteApiController::class . '::updateAction',
     'access' => 'public',
     'methods' => ['POST'],
 ];


### PR DESCRIPTION
## Summary
- add `NoteApiController` with `updateAction`
- strip `updateAction` from `NoteController`
- route note AJAX endpoint to the new API controller
- update tests for `NoteApiController`

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-intl --ignore-platform-req=ext-xml --ignore-platform-req=ext-xmlwriter`
- `./vendor/bin/phpunit -c phpunit.xml.dist` *(fails: PHPUnit requires the dom, xml and xmlwriter extensions)*
