### PR TITLE
Use FrontendUserProvider in session controllers

### DIFF
--- a/Classes/Controller/SessionProposalController.php
+++ b/Classes/Controller/SessionProposalController.php
@@ -6,7 +6,7 @@ namespace Ndrstmr\Dt3Pace\Controller;
 
 use Ndrstmr\Dt3Pace\Domain\Model\Session;
 use Ndrstmr\Dt3Pace\Domain\Model\SessionStatus;
-use Ndrstmr\Dt3Pace\Domain\Repository\FrontendUserRepository;
+use Ndrstmr\Dt3Pace\Service\FrontendUserProvider;
 use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
@@ -15,21 +15,21 @@ class SessionProposalController extends ActionController
 {
     public function __construct(
         private readonly SessionRepository $sessionRepository,
-        private readonly FrontendUserRepository $frontendUserRepository,
+        private readonly FrontendUserProvider $frontendUserProvider,
         private readonly PersistenceManager $persistenceManager
     ) {
     }
 
     public function newAction(): void
     {
-        if ($this->getCurrentFrontendUser() === null) {
+        if ($this->frontendUserProvider->getCurrentFrontendUser() === null) {
             throw new \RuntimeException('Login required', 166832);
         }
     }
 
     public function createAction(Session $newSession): void
     {
-        $user = $this->getCurrentFrontendUser();
+        $user = $this->frontendUserProvider->getCurrentFrontendUser();
         if ($user === null) {
             throw new \RuntimeException('Login required', 166833);
         }
@@ -45,12 +45,4 @@ class SessionProposalController extends ActionController
         $this->view->assign('sessions', $this->sessionRepository->findProposed());
     }
 
-    private function getCurrentFrontendUser(): ?\Ndrstmr\Dt3Pace\Domain\Model\FrontendUser
-    {
-        $uid = (int)($GLOBALS['TSFE']->fe_user->user['uid'] ?? 0);
-        if ($uid === 0) {
-            return null;
-        }
-        return $this->frontendUserRepository->findByUid($uid);
-    }
 }

--- a/Classes/Controller/SessionVoteController.php
+++ b/Classes/Controller/SessionVoteController.php
@@ -7,7 +7,7 @@ namespace Ndrstmr\Dt3Pace\Controller;
 use Ndrstmr\Dt3Pace\Domain\Model\Vote;
 use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
 use Ndrstmr\Dt3Pace\Domain\Repository\VoteRepository;
-use Ndrstmr\Dt3Pace\Domain\Repository\FrontendUserRepository;
+use Ndrstmr\Dt3Pace\Service\FrontendUserProvider;
 use Ndrstmr\Dt3Pace\Event\AfterVoteAddedEvent;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -19,7 +19,7 @@ class SessionVoteController extends ActionController
     public function __construct(
         private readonly SessionRepository $sessionRepository,
         private readonly VoteRepository $voteRepository,
-        private readonly FrontendUserRepository $frontendUserRepository,
+        private readonly FrontendUserProvider $frontendUserProvider,
         private readonly PersistenceManager $persistenceManager,
         EventDispatcherInterface $eventDispatcher
     ) {
@@ -28,7 +28,7 @@ class SessionVoteController extends ActionController
 
     public function voteAction(int $session): JsonResponse
     {
-        $user = $this->getCurrentFrontendUser();
+        $user = $this->frontendUserProvider->getCurrentFrontendUser();
         if ($user === null) {
             return new JsonResponse(['success' => false], 403);
         }
@@ -51,12 +51,4 @@ class SessionVoteController extends ActionController
         return new JsonResponse(['success' => true, 'votes' => $sessionObj->getVotes()]);
     }
 
-    private function getCurrentFrontendUser(): ?\Ndrstmr\Dt3Pace\Domain\Model\FrontendUser
-    {
-        $uid = (int)($GLOBALS['TSFE']->fe_user->user['uid'] ?? 0);
-        if ($uid === 0) {
-            return null;
-        }
-        return $this->frontendUserRepository->findByUid($uid);
-    }
 }


### PR DESCRIPTION
## Summary
- inject `FrontendUserProvider` into `SessionVoteController` and `SessionProposalController`
- use the provider to retrieve the current user
- update unit tests accordingly

## Testing
- `composer install --no-interaction --ignore-platform-req=ext-dom --ignore-platform-req=ext-intl --ignore-platform-req=ext-xml --ignore-platform-req=ext-xmlwriter`
- `vendor/bin/php-cs-fixer fix` *(pre-commit)*
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: missing PHP extensions)*
