### PR TITLE
Implement CSRF protected AJAX middleware

### DIFF
--- a/Classes/Controller/NoteApiController.php
+++ b/Classes/Controller/NoteApiController.php
@@ -8,6 +8,10 @@ use Ndrstmr\Dt3Pace\Domain\Model\Note;
 use Ndrstmr\Dt3Pace\Domain\Repository\NoteRepository;
 use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
 use Ndrstmr\Dt3Pace\Service\FrontendUserProvider;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\SecurityAspect;
+use TYPO3\CMS\Core\Security\RequestToken;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
@@ -24,6 +28,11 @@ class NoteApiController extends ActionController
 
     public function updateAction(int $session, string $note): JsonResponse
     {
+        $context = GeneralUtility::makeInstance(Context::class);
+        $securityAspect = SecurityAspect::provideIn($context);
+        if (!$securityAspect->getReceivedRequestToken() instanceof RequestToken) {
+            return new JsonResponse(['success' => false], 403);
+        }
         $user = $this->frontendUserProvider->getCurrentFrontendUser();
         if ($user === null) {
             return new JsonResponse(['success' => false], 403);

--- a/Classes/Controller/SessionVoteController.php
+++ b/Classes/Controller/SessionVoteController.php
@@ -9,6 +9,10 @@ use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
 use Ndrstmr\Dt3Pace\Domain\Repository\VoteRepository;
 use Ndrstmr\Dt3Pace\Service\FrontendUserProvider;
 use Ndrstmr\Dt3Pace\Event\AfterVoteAddedEvent;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\SecurityAspect;
+use TYPO3\CMS\Core\Security\RequestToken;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
@@ -28,6 +32,11 @@ class SessionVoteController extends ActionController
 
     public function voteAction(int $session): JsonResponse
     {
+        $context = GeneralUtility::makeInstance(Context::class);
+        $securityAspect = SecurityAspect::provideIn($context);
+        if (!$securityAspect->getReceivedRequestToken() instanceof RequestToken) {
+            return new JsonResponse(['success' => false], 403);
+        }
         $user = $this->frontendUserProvider->getCurrentFrontendUser();
         if ($user === null) {
             return new JsonResponse(['success' => false], 403);

--- a/Configuration/Frontend/AjaxRoutes.php
+++ b/Configuration/Frontend/AjaxRoutes.php
@@ -1,0 +1,21 @@
+<?php
+use Ndrstmr\Dt3Pace\Controller\SessionVoteController;
+use Ndrstmr\Dt3Pace\Controller\SessionApiController;
+use Ndrstmr\Dt3Pace\Controller\NoteApiController;
+
+return [
+    'dt3pace_session_vote' => [
+        'path' => '/dt3pace/session/vote',
+        'target' => SessionVoteController::class . '::voteAction',
+        'methods' => ['POST'],
+    ],
+    'dt3pace_sessions_json' => [
+        'path' => '/dt3pace/sessions/json',
+        'target' => SessionApiController::class . '::listJsonAction',
+    ],
+    'dt3pace_note_update' => [
+        'path' => '/dt3pace/note/update',
+        'target' => NoteApiController::class . '::updateAction',
+        'methods' => ['POST'],
+    ],
+];

--- a/Resources/Public/JavaScript/Note.js
+++ b/Resources/Public/JavaScript/Note.js
@@ -9,7 +9,10 @@ document.addEventListener('DOMContentLoaded', () => {
     timer = setTimeout(() => {
       fetch(TYPO3.settings.ajaxUrls['dt3pace_note_update'], {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-TYPO3-RequestToken': TYPO3.settings.security.csrfToken
+        },
         body: JSON.stringify({
           session: textarea.dataset.session,
           note: textarea.value

--- a/Resources/Public/JavaScript/Vote.js
+++ b/Resources/Public/JavaScript/Vote.js
@@ -3,7 +3,10 @@ document.addEventListener('DOMContentLoaded', () => {
     btn.addEventListener('click', () => {
       fetch(TYPO3.settings.ajaxUrls['dt3pace_session_vote'], {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-TYPO3-RequestToken': TYPO3.settings.security.csrfToken
+        },
         body: JSON.stringify({ session: btn.dataset.session })
       }).then(r => r.json()).then(data => {
         if (data.success) {

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -48,22 +48,9 @@ ExtensionUtility::configurePlugin('Ndrstmr.Dt3Pace', 'Eventsummary', [
     NoteController::class => 'summary'
 ], []);
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['ajaxRoutes']['dt3pace_session_vote'] = [
-    'path' => '/dt3pace/session/vote',
-    'target' => SessionVoteController::class . '::voteAction',
-    'access' => 'public',
-    'methods' => ['POST'],
-];
-
-$GLOBALS['TYPO3_CONF_VARS']['FE']['ajaxRoutes']['dt3pace_sessions_json'] = [
-    'path' => '/dt3pace/sessions/json',
-    'target' => SessionApiController::class . '::listJsonAction',
-    'access' => 'public',
-];
-
-$GLOBALS['TYPO3_CONF_VARS']['FE']['ajaxRoutes']['dt3pace_note_update'] = [
-    'path' => '/dt3pace/note/update',
-    'target' => NoteApiController::class . '::updateAction',
-    'access' => 'public',
-    'methods' => ['POST'],
-];
+foreach (require __DIR__ . '/Configuration/Frontend/AjaxRoutes.php' as $identifier => $config) {
+    $GLOBALS['TYPO3_CONF_VARS']['FE']['ajaxRoutes'][$identifier] = $config + [
+        'access' => \TYPO3\CMS\Frontend\Middleware\FrontendAjaxMiddleware::class,
+        'csrf' => true,
+    ];
+}


### PR DESCRIPTION
## Summary
- add AJAX middleware registration using `FrontendAjaxMiddleware`
- include CSRF header in Vote.js and Note.js requests
- check `RequestToken` in vote and note API actions

## Testing
- `composer install` *(fails: ext-dom / ext-intl missing)*
- `vendor/bin/phpunit -c phpunit.xml.dist` *(fails: command not found)*
- `vendor/bin/phpstan analyse --configuration phpstan.neon.dist` *(fails: command not found)*
- `vendor/bin/php-cs-fixer fix --dry-run` *(fails: command not found)*
