### PR TITLE
Add DB indexes for Session and Vote entities

### DIFF
--- a/Classes/Domain/Model/Session.php
+++ b/Classes/Domain/Model/Session.php
@@ -14,7 +14,14 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
  * Represents a conference session.
  */
 #[ORM\Entity]
-#[ORM\Table(name: 'tx_dt3pace_domain_model_session')]
+#[ORM\Table(
+    name: 'tx_dt3pace_domain_model_session',
+    indexes: [
+        new ORM\Index(columns: ['status']),
+        new ORM\Index(columns: ['time_slot']),
+        new ORM\Index(columns: ['room']),
+    ]
+)]
 class Session extends AbstractEntity
 {
     /**

--- a/Classes/Domain/Model/Vote.php
+++ b/Classes/Domain/Model/Vote.php
@@ -12,7 +12,14 @@ use Ndrstmr\Dt3Pace\Domain\Model\FrontendUser;
  * Represents a single vote for a session.
  */
 #[ORM\Entity]
-#[ORM\Table(name: 'tx_dt3pace_domain_model_vote', uniqueConstraints: [new ORM\UniqueConstraint(name: 'session_voter_unique', columns: ['session', 'voter'])])]
+#[ORM\Table(
+    name: 'tx_dt3pace_domain_model_vote',
+    uniqueConstraints: [new ORM\UniqueConstraint(name: 'session_voter_unique', columns: ['session', 'voter'])],
+    indexes: [
+        new ORM\Index(columns: ['voter']),
+        new ORM\Index(columns: ['session']),
+    ]
+)]
 class Vote extends AbstractEntity
 {
     #[ORM\ManyToOne(targetEntity: Session::class)]

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -16,3 +16,19 @@ extensions:
   entity has been persisted.
 * ``Ndrstmr\Dt3Pace\Event\SessionStatusChangedEvent`` – emitted whenever a
   ``Session`` changes its status.
+
+Database Indexes
+================
+
+Several database indexes improve lookup performance. If you use Doctrine
+migrations, they can be created automatically. Alternatively run the following
+SQL statements after installing the extension::
+
+    CREATE INDEX idx_session_status ON tx_dt3pace_domain_model_session (status);
+    CREATE INDEX idx_session_time_slot ON tx_dt3pace_domain_model_session (time_slot);
+    CREATE INDEX idx_session_room ON tx_dt3pace_domain_model_session (room);
+    CREATE INDEX idx_vote_voter ON tx_dt3pace_domain_model_vote (voter);
+    CREATE INDEX idx_vote_session ON tx_dt3pace_domain_model_vote (session);
+
+When using Doctrine migrations call ``bin/typo3cms doctrine:migrations:diff``
+after updating the entities and apply the generated migration.


### PR DESCRIPTION
## Summary
- add Doctrine indexes for Session status, time slot and room
- add Doctrine indexes for Vote voter and session
- document how to create these indexes

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist` *(fails: SessionControllersTest cannot be found; return value for getStatus cannot be generated; failing assertion in NoteControllerTest)*
