### PR TITLE
Restrict scheduler module access

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -32,3 +32,14 @@ SQL statements after installing the extension::
 
 When using Doctrine migrations call ``bin/typo3cms doctrine:migrations:diff``
 after updating the entities and apply the generated migration.
+
+Scheduler Permissions
+=====================
+
+Only backend users with sufficient permissions should access the scheduler
+module. By default the module requires admin privileges. You can change this
+via the extension configuration::
+
+    $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['dt3_pace']['schedulerModuleAccess'] = 'user,group';
+
+Assign the module to specific backend groups after adjusting the access value.

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
@@ -65,7 +66,7 @@ ExtensionUtility::registerModule(
     '',
     [SchedulerController::class => 'show,updateSessionSlot'],
     [
-        'access' => 'user,group',
+        'access' => (string)($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['dt3_pace']['schedulerModuleAccess'] ?? 'admin'),
         'iconIdentifier' => 'actions-calendar',
         'labels' => 'LLL:EXT:dt3_pace/Resources/Private/Language/locallang_dt3pace.xlf:module.scheduler',
     ]


### PR DESCRIPTION
## Summary
- make scheduler backend module require admin by default and make it configurable
- document how to change scheduler permissions

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist`
- `vendor/bin/phpstan analyse --error-format=table`
