### PR TITLE
Add CI workflow and badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-php@v2
+        with:
+          php-version: '8.2'
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --ignore-platform-reqs
+      - name: Run phpstan
+        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+      - name: Run phpunit
+        run: vendor/bin/phpunit -c phpunit.xml.dist

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # dt3_pace
 
+[![CI](https://github.com/ndrstmr/dt3_pace/actions/workflows/ci.yml/badge.svg)](https://github.com/ndrstmr/dt3_pace/actions/workflows/ci.yml)
+
 > **Achtung: Automatisch generierter Code**
 > Dieser Code wurde von einem KI-Code-Agenten (Google Gemini) auf Basis eines detaillierten Prompts erstellt. Er dient als Grundlage und Beschleuniger für die Entwicklung.
 > Jeder Entwickler ist verpflichtet, den Code vor einem produktiven Einsatz eigenständig und sorgfältig zu überprüfen, zu testen und gegebenenfalls anzupassen. Es wird keinerlei Haftung für Fehler, Sicherheitslücken oder Fehlfunktionen übernommen.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow for PHP QA
- display CI status badge in README

## Testing
- `composer install --ignore-platform-reqs`
- `vendor/bin/phpstan analyse -c phpstan.neon.dist` *(fails: 47 errors)*
- `vendor/bin/phpunit -c phpunit.xml.dist` *(fails: missing extensions)*

------
https://chatgpt.com/codex/tasks/task_e_686151cb2a18832ea4fe69a662d025ca