### PR TITLE
Fix failing PHPUnit tests

### DIFF
--- a/Tests/Unit/Controller/NoteControllerTest.php
+++ b/Tests/Unit/Controller/NoteControllerTest.php
@@ -14,10 +14,16 @@ use Ndrstmr\Dt3Pace\Domain\Repository\FrontendUserRepository;
 use Ndrstmr\Dt3Pace\Service\FrontendUserProvider;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\SecurityAspect;
+use TYPO3\CMS\Core\Security\RequestToken;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use PHPUnit\Framework\TestCase;
 
 class NoteControllerTest extends TestCase
 {
+    private Context $context;
+
     protected function setUp(): void
     {
         $GLOBALS['TSFE'] = new class () {
@@ -30,6 +36,17 @@ class NoteControllerTest extends TestCase
                 };
             }
         };
+
+        $this->context = new Context();
+        $securityAspect = SecurityAspect::provideIn($this->context);
+        $securityAspect->setReceivedRequestToken(RequestToken::create('test'));
+        GeneralUtility::setSingletonInstance(Context::class, $this->context);
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::removeSingletonInstance(Context::class, $this->context);
+        unset($GLOBALS['TSFE']);
     }
 
     public function testUpdateActionCreatesNote(): void

--- a/Tests/Unit/Controller/SessionControllerTest.php
+++ b/Tests/Unit/Controller/SessionControllerTest.php
@@ -13,6 +13,10 @@ use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
 use Ndrstmr\Dt3Pace\Domain\Repository\VoteRepository;
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\SecurityAspect;
+use TYPO3\CMS\Core\Security\RequestToken;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Ndrstmr\Dt3Pace\Domain\Model\FrontendUser;
 use Ndrstmr\Dt3Pace\Service\FrontendUserProvider;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
@@ -59,6 +63,21 @@ class TestableSessionVoteController extends SessionVoteController
 
 class SessionControllerTest extends TestCase
 {
+    private Context $context;
+
+    protected function setUp(): void
+    {
+        $this->context = new Context();
+        SecurityAspect::provideIn($this->context)
+            ->setReceivedRequestToken(RequestToken::create('test'));
+        GeneralUtility::setSingletonInstance(Context::class, $this->context);
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::removeSingletonInstance(Context::class, $this->context);
+    }
+
     public function testCreateActionAddsSession(): void
     {
         $session = new Session();

--- a/Tests/Unit/SchedulerControllerTest.php
+++ b/Tests/Unit/SchedulerControllerTest.php
@@ -6,6 +6,7 @@ namespace Ndrstmr\Dt3Pace\Tests\Unit;
 
 use Ndrstmr\Dt3Pace\Controller\SchedulerController;
 use Ndrstmr\Dt3Pace\Domain\Model\Session;
+use Ndrstmr\Dt3Pace\Domain\Model\SessionStatus;
 use Ndrstmr\Dt3Pace\Domain\Repository\RoomRepository;
 use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
 use Ndrstmr\Dt3Pace\Domain\Repository\TimeSlotRepository;
@@ -19,6 +20,7 @@ class SchedulerControllerTest extends TestCase
     public function testUpdateSessionSlotActionUpdatesSession(): void
     {
         $session = $this->createMock(Session::class);
+        $session->method('getStatus')->willReturn(SessionStatus::PROPOSED);
         $session->expects($this->once())->method('setRoom');
         $session->expects($this->once())->method('setTimeSlot');
         $session->expects($this->once())->method('setStatus');


### PR DESCRIPTION
## Summary
- rename session controller test file
- stub enumeration return value in SchedulerControllerTest
- prepare security context in NoteControllerTest and SessionControllerTest

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist`

------
https://chatgpt.com/codex/tasks/task_e_68615c1444a0832e88b708a8861cb8ce