### PR TITLE
Improve voting integrity and UX

### DIFF
--- a/Classes/Controller/BaseAjaxController.php
+++ b/Classes/Controller/BaseAjaxController.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Dt3Pace\Controller;

--- a/Classes/Controller/BaseAjaxController.php
+++ b/Classes/Controller/BaseAjaxController.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Controller;
+
+use Ndrstmr\Dt3Pace\Service\FrontendUserProvider;
+use Ndrstmr\Dt3Pace\Domain\Model\FrontendUser;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\SecurityAspect;
+use TYPO3\CMS\Core\Security\RequestToken;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+abstract class BaseAjaxController extends ActionController
+{
+    public function __construct(protected readonly FrontendUserProvider $frontendUserProvider)
+    {
+    }
+
+    protected function getAuthenticatedUser(): ?FrontendUser
+    {
+        $context = GeneralUtility::makeInstance(Context::class);
+        $securityAspect = SecurityAspect::provideIn($context);
+        if (!$securityAspect->getReceivedRequestToken() instanceof RequestToken) {
+            return null;
+        }
+
+        return $this->frontendUserProvider->getCurrentFrontendUser();
+    }
+}

--- a/Classes/Controller/NoteApiController.php
+++ b/Classes/Controller/NoteApiController.php
@@ -9,32 +9,24 @@ use Ndrstmr\Dt3Pace\Domain\Model\Session;
 use Ndrstmr\Dt3Pace\Domain\Repository\NoteRepository;
 use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
 use Ndrstmr\Dt3Pace\Service\FrontendUserProvider;
-use TYPO3\CMS\Core\Context\Context;
-use TYPO3\CMS\Core\Context\SecurityAspect;
-use TYPO3\CMS\Core\Security\RequestToken;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use Ndrstmr\Dt3Pace\Controller\BaseAjaxController;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
-class NoteApiController extends ActionController
+class NoteApiController extends BaseAjaxController
 {
     public function __construct(
         private readonly NoteRepository $noteRepository,
         private readonly SessionRepository $sessionRepository,
-        private readonly FrontendUserProvider $frontendUserProvider,
+        FrontendUserProvider $frontendUserProvider,
         private readonly PersistenceManager $persistenceManager
     ) {
+        parent::__construct($frontendUserProvider);
     }
 
     public function updateAction(int $session, string $note): JsonResponse
     {
-        $context = GeneralUtility::makeInstance(Context::class);
-        $securityAspect = SecurityAspect::provideIn($context);
-        if (!$securityAspect->getReceivedRequestToken() instanceof RequestToken) {
-            return new JsonResponse(['success' => false], 403);
-        }
-        $user = $this->frontendUserProvider->getCurrentFrontendUser();
+        $user = $this->getAuthenticatedUser();
         if ($user === null) {
             return new JsonResponse(['success' => false], 403);
         }

--- a/Classes/Controller/SessionProposalController.php
+++ b/Classes/Controller/SessionProposalController.php
@@ -10,6 +10,7 @@ use Ndrstmr\Dt3Pace\Service\FrontendUserProvider;
 use Ndrstmr\Dt3Pace\Domain\Repository\SessionRepository;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
+use Psr\Http\Message\ResponseInterface;
 
 class SessionProposalController extends ActionController
 {
@@ -20,24 +21,28 @@ class SessionProposalController extends ActionController
     ) {
     }
 
-    public function newAction(): void
+    public function newAction(): ResponseInterface
     {
         if ($this->frontendUserProvider->getCurrentFrontendUser() === null) {
-            throw new \RuntimeException('Login required', 166832);
+            $this->addFlashMessage('Please log in to propose a session.');
+            return $this->redirectToUri('/login');
         }
+
+        return $this->htmlResponse();
     }
 
-    public function createAction(Session $newSession): void
+    public function createAction(Session $newSession): ResponseInterface
     {
         $user = $this->frontendUserProvider->getCurrentFrontendUser();
         if ($user === null) {
-            throw new \RuntimeException('Login required', 166833);
+            $this->addFlashMessage('Please log in to propose a session.');
+            return $this->redirectToUri('/login');
         }
         $newSession->setStatus(SessionStatus::PROPOSED);
         $newSession->setProposer($user);
         $this->sessionRepository->add($newSession);
         $this->persistenceManager->persistAll();
-        $this->redirect('listProposals');
+        return $this->redirect('listProposals');
     }
 
     public function listProposalsAction(): void

--- a/Classes/Domain/Model/Session.php
+++ b/Classes/Domain/Model/Session.php
@@ -30,6 +30,12 @@ class Session extends AbstractEntity
     protected string $description = '';
 
     /**
+     * Slug used for routing
+     */
+    #[ORM\Column(type: 'string', length: 255, unique: true)]
+    protected string $slug = '';
+
+    /**
      * Current status
      */
     #[ORM\Column(type: 'string', enumType: SessionStatus::class)]
@@ -96,6 +102,16 @@ class Session extends AbstractEntity
     public function setDescription(string $description): void
     {
         $this->description = $description;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(string $slug): void
+    {
+        $this->slug = $slug;
     }
 
     public function getStatus(): SessionStatus

--- a/Classes/Domain/Model/Vote.php
+++ b/Classes/Domain/Model/Vote.php
@@ -12,7 +12,10 @@ use Ndrstmr\Dt3Pace\Domain\Model\FrontendUser;
  * Represents a single vote for a session.
  */
 #[ORM\Entity]
-#[ORM\Table(name: 'tx_dt3pace_domain_model_vote')]
+#[ORM\Table(
+    name: 'tx_dt3pace_domain_model_vote',
+    uniqueConstraints: [new ORM\UniqueConstraint(name: 'uniq_session_voter', columns: ['session_id', 'voter_id'])]
+)]
 class Vote extends AbstractEntity
 {
     #[ORM\ManyToOne(targetEntity: Session::class)]

--- a/Configuration/TCA/tx_dt3pace_domain_model_session.php
+++ b/Configuration/TCA/tx_dt3pace_domain_model_session.php
@@ -13,7 +13,7 @@ return [
         'iconfile' => 'EXT:dt3_pace/Resources/Public/Icons/tx_dt3pace_domain_model_session.svg',
     ],
     'interface' => [
-        'showRecordFieldList' => 'title,status,room,time_slot',
+        'showRecordFieldList' => 'title,slug,status,room,time_slot',
     ],
     'columns' => [
         'hidden' => [
@@ -29,6 +29,17 @@ return [
                 'required' => true,
             ],
         ],
+        'slug' => [
+            'label' => 'LLL:EXT:dt3_pace/Resources/Private/Language/locallang_db.xlf:tx_dt3pace_domain_model_session.slug',
+            'config' => [
+                'type' => 'slug',
+                'generatorOptions' => [
+                    'fields' => ['title'],
+                ],
+                'fallbackCharacter' => '-',
+                'eval' => 'uniqueInSite',
+            ],
+        ],
         'description' => [
             'label' => 'Description',
             'config' => [
@@ -37,10 +48,16 @@ return [
             ],
         ],
         'status' => [
-            'label' => 'Status',
+            'label' => 'LLL:EXT:dt3_pace/Resources/Private/Language/locallang_db.xlf:tx_dt3pace_domain_model_session.status',
             'config' => [
-                'type' => 'input',
-                'size' => 20,
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['LLL:EXT:dt3_pace/Resources/Private/Language/locallang_db.xlf:tx_dt3pace_domain_model_session.status.I.proposed', 'proposed'],
+                    ['LLL:EXT:dt3_pace/Resources/Private/Language/locallang_db.xlf:tx_dt3pace_domain_model_session.status.I.scheduled', 'scheduled'],
+                    ['LLL:EXT:dt3_pace/Resources/Private/Language/locallang_db.xlf:tx_dt3pace_domain_model_session.status.I.rejected', 'rejected'],
+                ],
+                'default' => 'proposed',
             ],
         ],
         'votes' => [
@@ -126,7 +143,7 @@ return [
     ],
     'types' => [
         '0' => [
-            'showitem' => '--div--;Allgemein, hidden, title, description, status, votes, is_published,'
+            'showitem' => '--div--;Allgemein, hidden, title, slug, description, status, votes, is_published,'
                 . '--div--;Relations, proposer, speakers, room, track, time_slot, slides',
         ],
     ],

--- a/Configuration/TCA/tx_dt3pace_domain_model_speaker.php
+++ b/Configuration/TCA/tx_dt3pace_domain_model_speaker.php
@@ -69,9 +69,14 @@ return [
             ],
         ],
         'slug' => [
-            'label' => 'Slug',
+            'label' => 'LLL:EXT:dt3_pace/Resources/Private/Language/locallang_db.xlf:tx_dt3pace_domain_model_speaker.slug',
             'config' => [
-                'type' => 'input',
+                'type' => 'slug',
+                'generatorOptions' => [
+                    'fields' => ['name'],
+                ],
+                'fallbackCharacter' => '-',
+                'eval' => 'uniqueInSite',
             ],
         ],
     ],

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -35,8 +35,11 @@ are not used::
     CREATE INDEX idx_session_status ON tx_dt3pace_domain_model_session (status);
     CREATE INDEX idx_session_time_slot ON tx_dt3pace_domain_model_session (time_slot);
     CREATE INDEX idx_session_room ON tx_dt3pace_domain_model_session (room);
+    CREATE UNIQUE INDEX uniq_session_slug ON tx_dt3pace_domain_model_session (slug);
     CREATE INDEX idx_vote_voter ON tx_dt3pace_domain_model_vote (voter);
     CREATE INDEX idx_vote_session ON tx_dt3pace_domain_model_vote (session);
+    ALTER TABLE tx_dt3pace_domain_model_vote
+        ADD CONSTRAINT uniq_session_voter UNIQUE (session_id, voter_id);
 
 Scheduler Permissions
 =====================
@@ -48,3 +51,32 @@ via the extension configuration::
     $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['dt3_pace']['schedulerModuleAccess'] = 'user,group';
 
 Assign the module to specific backend groups after adjusting the access value.
+
+Editor Guide
+============
+
+Editors create and manage sessions and speakers using the backend modules
+"Sessions" and "Speakers". Schedule sessions by opening the "Scheduler" module
+and drag the records onto the desired time slots. Save the changes via the
+"Update" button.
+
+Developer Notes
+===============
+
+Install the dependencies with ``composer install`` and run the QA tools before
+submitting patches::
+
+    vendor/bin/phpstan analyse
+    vendor/bin/phpunit
+
+Extension Hooks
+===============
+
+Listen to ``AfterVoteAddedEvent`` or ``SessionStatusChangedEvent`` to trigger
+custom logic when votes are cast or session statuses change.
+
+Contribution Guide
+==================
+
+Pull requests are welcome. Follow PSR-12 coding style and make sure all tests
+pass before opening a PR.

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.0">
+  <file source-language="en" datatype="plaintext" original="messages">
+    <body>
+      <trans-unit id="tx_dt3pace_domain_model_session.slug" xml:space="preserve">
+        <source>Slug</source>
+      </trans-unit>
+      <trans-unit id="tx_dt3pace_domain_model_session.status" xml:space="preserve">
+        <source>Status</source>
+      </trans-unit>
+      <trans-unit id="tx_dt3pace_domain_model_session.status.I.proposed" xml:space="preserve">
+        <source>Proposed</source>
+      </trans-unit>
+      <trans-unit id="tx_dt3pace_domain_model_session.status.I.scheduled" xml:space="preserve">
+        <source>Scheduled</source>
+      </trans-unit>
+      <trans-unit id="tx_dt3pace_domain_model_session.status.I.rejected" xml:space="preserve">
+        <source>Rejected</source>
+      </trans-unit>
+      <trans-unit id="tx_dt3pace_domain_model_speaker.slug" xml:space="preserve">
+        <source>Slug</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Templates/Session/Show.html
+++ b/Resources/Private/Templates/Session/Show.html
@@ -1,7 +1,7 @@
 <f:layout name="Default" />
 <f:section name="Main">
   <h2>{session.title}</h2>
-  <p>{session.description}</p>
+  <p><f:format.html>{session.description}</f:format.html></p>
   <p><strong>Room:</strong> {session.room.name}</p>
   <p><strong>Time:</strong> {session.timeSlot.start -> f:format.date(format:'H:i')}</p>
   <f:if condition="{session.slides}">
@@ -13,6 +13,7 @@
   <f:if condition="{isLoggedIn}">
     <h3>Meine Notizen</h3>
     <textarea id="session-note" data-session="{session.uid}" rows="6">{note.noteText}</textarea>
+    <span id="note-saved" class="note-saved" hidden>✅ Gespeichert</span>
     <f:asset.script identifier="note-js" src="EXT:dt3_pace/Resources/Public/JavaScript/Note.js" />
   </f:if>
 </f:section>

--- a/Resources/Private/Templates/Speaker/Show.html
+++ b/Resources/Private/Templates/Speaker/Show.html
@@ -2,5 +2,5 @@
 <f:section name="Main">
   <h2>{speaker.name}</h2>
   <p>{speaker.company}</p>
-  <p>{speaker.bio}</p>
+  <p><f:format.html>{speaker.bio}</f:format.html></p>
 </f:section>

--- a/Resources/Public/JavaScript/Note.js
+++ b/Resources/Public/JavaScript/Note.js
@@ -3,6 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!textarea) {
     return;
   }
+  const indicator = document.getElementById('note-saved');
   let timer;
   textarea.addEventListener('input', () => {
     clearTimeout(timer);
@@ -17,6 +18,13 @@ document.addEventListener('DOMContentLoaded', () => {
           session: textarea.dataset.session,
           note: textarea.value
         })
+      }).then(() => {
+        if (indicator) {
+          indicator.hidden = false;
+          setTimeout(() => {
+            indicator.hidden = true;
+          }, 2000);
+        }
       });
     }, 1500);
   });

--- a/Resources/Public/JavaScript/Vote.js
+++ b/Resources/Public/JavaScript/Vote.js
@@ -10,12 +10,14 @@ document.addEventListener('DOMContentLoaded', () => {
         },
         body: JSON.stringify({ session: btn.dataset.session })
       }).then(r => r.json()).then(data => {
+        const li = btn.closest('li');
         if (data.success) {
-          const li = btn.closest('li');
           li.querySelector('.votes').textContent = data.votes;
           li.querySelector('.vote-message').textContent = 'Thanks for voting!';
           li.querySelector('.vote-message').hidden = false;
         } else {
+          li.querySelector('.vote-message').textContent = 'Du hast bereits abgestimmt';
+          li.querySelector('.vote-message').hidden = false;
           btn.disabled = false;
         }
       }).catch(() => {

--- a/Tests/Unit/Controller/SessionControllerTest.php
+++ b/Tests/Unit/Controller/SessionControllerTest.php
@@ -90,10 +90,18 @@ class SessionControllerTest extends TestCase
             ->setReceivedRequestToken(RequestToken::create('test'));
         GeneralUtility::setSingletonInstance(Context::class, $this->context);
 
-        $this->mockConnection = new class {
-            public function beginTransaction(): void {}
-            public function commit(): void {}
-            public function rollBack(): void {}
+        $this->mockConnection = new class () {
+            public function beginTransaction(): void
+            {
+            }
+
+            public function commit(): void
+            {
+            }
+
+            public function rollBack(): void
+            {
+            }
         };
 
         $this->connectionPool = $this->createMock(ConnectionPool::class);
@@ -208,7 +216,8 @@ class SessionControllerTest extends TestCase
 
         $voteRepository->expects($this->once())->method('add');
         $sessionRepository->expects($this->once())->method('update')->with($session);
-        $driverException = new class ('error') extends \Doctrine\DBAL\Driver\AbstractException {};
+        $driverException = new class('error') extends \Doctrine\DBAL\Driver\AbstractException {
+        };
         $persistenceManager->method('persistAll')->willThrowException(new UniqueConstraintViolationException($driverException, null));
 
         $controller = new TestableSessionVoteController($sessionRepository, $voteRepository, $frontendUserProvider, $persistenceManager, $eventDispatcher);
@@ -244,7 +253,8 @@ class SessionControllerTest extends TestCase
         $persistenceManager->method('persistAll')->willReturnCallback(static function () use (&$callCount) {
             ++$callCount;
             if ($callCount === 2) {
-                $driverException = new class ('error') extends \Doctrine\DBAL\Driver\AbstractException {};
+                $driverException = new class('error') extends \Doctrine\DBAL\Driver\AbstractException {
+                };
                 throw new UniqueConstraintViolationException($driverException, null);
             }
             return null;

--- a/Tests/Unit/Template/TemplateOutputTest.php
+++ b/Tests/Unit/Template/TemplateOutputTest.php
@@ -11,12 +11,12 @@ class TemplateOutputTest extends TestCase
     public function testSessionDescriptionUsesHtmlFormatter(): void
     {
         $template = file_get_contents(__DIR__ . '/../../../Resources/Private/Templates/Session/Show.html');
-        $this->assertStringContainsString('<f:format.html>{session.description}</f:format.html>', $template);
+        $this->assertStringContainsString('<f:format.html>{session.description}</f:format.html>', (string) $template);
     }
 
     public function testSpeakerBioUsesHtmlFormatter(): void
     {
         $template = file_get_contents(__DIR__ . '/../../../Resources/Private/Templates/Speaker/Show.html');
-        $this->assertStringContainsString('<f:format.html>{speaker.bio}</f:format.html>', $template);
+        $this->assertStringContainsString('<f:format.html>{speaker.bio}</f:format.html>', (string) $template);
     }
 }

--- a/Tests/Unit/Template/TemplateOutputTest.php
+++ b/Tests/Unit/Template/TemplateOutputTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Dt3Pace\Tests\Unit\Template;
+
+use PHPUnit\Framework\TestCase;
+
+class TemplateOutputTest extends TestCase
+{
+    public function testSessionDescriptionUsesHtmlFormatter(): void
+    {
+        $template = file_get_contents(__DIR__ . '/../../../Resources/Private/Templates/Session/Show.html');
+        $this->assertStringContainsString('<f:format.html>{session.description}</f:format.html>', $template);
+    }
+
+    public function testSpeakerBioUsesHtmlFormatter(): void
+    {
+        $template = file_get_contents(__DIR__ . '/../../../Resources/Private/Templates/Speaker/Show.html');
+        $this->assertStringContainsString('<f:format.html>{speaker.bio}</f:format.html>', $template);
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -72,7 +72,7 @@ parameters:
 
 		-
 			message: "#^Attribute class Doctrine\\\\ORM\\\\Mapping\\\\Column does not exist\\.$#"
-			count: 5
+			count: 6
 			path: Classes/Domain/Model/Session.php
 
 		-
@@ -162,6 +162,10 @@ parameters:
 
 		-
 			message: "#^Attribute class Doctrine\\\\ORM\\\\Mapping\\\\Table does not exist\\.$#"
+			count: 1
+			path: Classes/Domain/Model/Vote.php
+		-
+			message: "#^Instantiated class Doctrine\\\\ORM\\\\Mapping\\\\UniqueConstraint not found\\.$#"
 			count: 1
 			path: Classes/Domain/Model/Vote.php
 


### PR DESCRIPTION
## Summary
- centralize CSRF and user checks in `BaseAjaxController`
- enforce unique votes on `(session_id, voter_id)`
- enhance note autosave UI and voting error feedback
- add slug/status TCA improvements with translations
- extend documentation with editor and developer hints

## Testing
- `composer install` *(failed: missing PHP extensions)*
- `vendor/bin/php-cs-fixer fix --dry-run` *(failed: no such file or directory)*
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G` *(failed: no such file or directory)*
- `vendor/bin/phpunit --colors=never` *(failed: no such file or directory)*
