### PR TITLE
Add ADR location decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,4 +96,8 @@ Nach jedem Sprint wird ein Review durchgeführt. Deine Aufgabe kann es sein, ein
 * **[Datum] - [Sprint X] - Entscheidung:** ...
 * **[Datum] - [Sprint X] - Abschluss:** Sprint X ist abgeschlossen. Alle DoD-Kriterien sind erfüllt. Starte Review-Prozess.
 
+## 9. Architekturentscheidungen
+
+Alle wesentlichen Architekturentscheidungen werden als sogenannte Architecture Decision Records (ADRs) im Verzeichnis `Documentation/adr/` festgehalten. Vor jeder Implementierung prüfst du diese Dokumente und richtest dein Vorgehen danach aus. Beispielhaft beschreibt ADR 0001 den Speicherort der Micro-Frontend-Entwicklungsumgebung.
+
 ---

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,5 +1,10 @@
 .. include:: /Includes.rst.txt
 
+.. toctree::
+   :hidden:
+
+   adr/Index
+
 ============================
 DT3-PACE Documentation
 ============================
@@ -80,3 +85,10 @@ Contribution Guide
 
 Pull requests are welcome. Follow PSR-12 coding style and make sure all tests
 pass before opening a PR.
+
+Architectural Decisions
+=======================
+
+This section documents significant architectural decisions made during the development of the DT3-PACE extension.
+
+`View the Architecture Decision Records (ADRs) <adr/Index.html>`_

--- a/Documentation/adr/0001-location-of-the-micro-frontend-development-environment.md
+++ b/Documentation/adr/0001-location-of-the-micro-frontend-development-environment.md
@@ -1,0 +1,33 @@
+# ADR 0001: Location of the Micro-Frontend Development Environment
+
+* **Status:** Accepted
+* **Date:** 2025-06-29
+* **Deciders:** Project Architect, AI Assistant Jules
+
+## Context and Problem Statement
+
+For the development of the interactive frontend components of the `DT3-PACE` extension, a hybrid Micro-Frontend (MFE) approach using Web Components has been chosen. The key architectural question is where the source code for this TypeScript-based application should be located, versioned, and developed.
+
+Two primary options were evaluated:
+
+* **Option A: In the TYPO3 Project Root.** The MFE would reside in a separate directory at the same level as the `packages` directory. This provides high autonomy for the frontend team but breaks the encapsulation of the TYPO3 extension.
+* **Option B: Within the Extension Directory.** The entire MFE development environment (including `package.json`, `vite.config.ts`, etc.) is located within the extension's `Resources/Private/Frontend/` directory.
+
+## Decision
+
+We have decisively chosen **Option B: Within the Extension Directory**.
+
+The entire source code for the Micro-Frontend will be developed and maintained within the `Resources/Private/Frontend/` directory of the `dt3_pace` extension. The build process will compile the final artifacts to the `Resources/Public/` directory.
+
+## Rationale and Consequences
+
+This decision aligns with the fundamental TYPO3 principles of **encapsulation and portability**.
+
+**Positive Consequences:**
+* **Full Encapsulation:** The `dt3_pace` extension is a self-contained, complete unit. Everything required to run, maintain, and further develop the extension is located in a single, version-controlled directory.
+* **Standard Compliance:** This approach perfectly respects the TYPO3 convention of separating non-web-accessible source code (`Resources/Private`) from publicly accessible, compiled assets (`Resources/Public`).
+* **Simplified Deployment & CI/CD:** Build processes are easier to automate as no cross-directory file operations are needed. The extension can be distributed as a single package (e.g., a ZIP file or a Git repository) and is always complete.
+* **Clarity:** There is a single source of truth for the entire extension, benefiting future developers and maintainers.
+
+**Negative Consequences / Trade-offs:**
+* **Tighter Organizational Coupling:** Purely frontend-focused teams might perceive their code as being "inside" a PHP project. This is considered a minor organizational trade-off that is heavily outweighed by the technical benefits of full encapsulation and portability for a distributable extension.

--- a/Documentation/adr/Index.rst
+++ b/Documentation/adr/Index.rst
@@ -1,0 +1,13 @@
+.. _adr-index:
+
+==============================
+Architecture Decision Records
+==============================
+
+Here we record the architectural decisions made for this project.
+
+.. toctree::
+   :maxdepth: 1
+
+   0001-location-of-the-micro-frontend-development-environment
+

--- a/Tests/Unit/Controller/SessionControllerTest.php
+++ b/Tests/Unit/Controller/SessionControllerTest.php
@@ -216,7 +216,7 @@ class SessionControllerTest extends TestCase
 
         $voteRepository->expects($this->once())->method('add');
         $sessionRepository->expects($this->once())->method('update')->with($session);
-        $driverException = new class('error') extends \Doctrine\DBAL\Driver\AbstractException {
+        $driverException = new class ('error') extends \Doctrine\DBAL\Driver\AbstractException {
         };
         $persistenceManager->method('persistAll')->willThrowException(new UniqueConstraintViolationException($driverException, null));
 
@@ -253,7 +253,7 @@ class SessionControllerTest extends TestCase
         $persistenceManager->method('persistAll')->willReturnCallback(static function () use (&$callCount) {
             ++$callCount;
             if ($callCount === 2) {
-                $driverException = new class('error') extends \Doctrine\DBAL\Driver\AbstractException {
+                $driverException = new class ('error') extends \Doctrine\DBAL\Driver\AbstractException {
                 };
                 throw new UniqueConstraintViolationException($driverException, null);
             }


### PR DESCRIPTION
## Summary
- document ADRs in project docs
- add ADR 0001 describing frontend code location
- refer to ADR index from main docs
- note architectural decisions in AGENTS.md

## Testing
- `composer install` *(fails: ext-dom missing)*
- `vendor/bin/phpstan analyse` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: command not found)*
