### PR TITLE
Fix PHP CS Fixer errors and improve request parsing

### DIFF
--- a/Classes/Controller/NoteApiController.php
+++ b/Classes/Controller/NoteApiController.php
@@ -55,13 +55,15 @@ class NoteApiController extends BaseAjaxController
      */
     public function processUpdateRequest(ServerRequestInterface $request): ResponseInterface
     {
-        $sessionId = (int)($request->getQueryParams()['session'] ?? $request->getParsedBody()['session'] ?? 0);
-        $note = (string)($request->getQueryParams()['note'] ?? $request->getParsedBody()['note'] ?? '');
-        
+        $parsedBody = $request->getParsedBody();
+        $parsedBody = \is_array($parsedBody) ? $parsedBody : [];
+        $sessionId = (int)($request->getQueryParams()['session'] ?? $parsedBody['session'] ?? 0);
+        $note = (string)($request->getQueryParams()['note'] ?? $parsedBody['note'] ?? '');
+
         if ($sessionId === 0) {
             return new JsonResponse(['success' => false, 'message' => 'Missing session parameter'], 400);
         }
-        
+
         return $this->updateAction($sessionId, $note);
     }
 }

--- a/Classes/Controller/SessionVoteController.php
+++ b/Classes/Controller/SessionVoteController.php
@@ -74,12 +74,14 @@ class SessionVoteController extends BaseAjaxController
      */
     public function processVoteRequest(ServerRequestInterface $request): ResponseInterface
     {
-        $sessionId = (int)($request->getQueryParams()['session'] ?? $request->getParsedBody()['session'] ?? 0);
-        
+        $parsedBody = $request->getParsedBody();
+        $parsedBody = \is_array($parsedBody) ? $parsedBody : [];
+        $sessionId = (int)($request->getQueryParams()['session'] ?? $parsedBody['session'] ?? 0);
+
         if ($sessionId === 0) {
             return new JsonResponse(['success' => false, 'message' => 'Missing session parameter'], 400);
         }
-        
+
         return $this->voteAction($sessionId);
     }
 


### PR DESCRIPTION
## Summary
- cast parsed body to array to satisfy phpstan
- ensure CS fixer compliance

## Testing
- `PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run --diff`
- `vendor/bin/phpstan analyse --error-format raw`
- `vendor/bin/phpunit --configuration phpunit.xml.dist --colors=never`

